### PR TITLE
Fix dependency versions, adapt to swift-macro-testing updates

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,13 +32,13 @@ let package = Package(
         // Tools for macro development
         .package(
             url: "https://github.com/stackotter/swift-macro-toolkit",
-            branch: "main"
+            from: "0.3.0"
         ),
 
         // Tools for macro development
         .package(
             url: "https://github.com/pointfreeco/swift-macro-testing",
-            branch: "main"
+            from: "0.2.1"
         ),
     ],
     targets: [

--- a/Tests/MacroCodableKitTests/AllOfCodable/AllOfMacroTests.swift
+++ b/Tests/MacroCodableKitTests/AllOfCodable/AllOfMacroTests.swift
@@ -28,7 +28,7 @@
                     @AllOfCodable
                     enum A {}
                     """
-                } matches: {
+                } diagnostics: {
                     """
                     @AllOfCodable
                     ┬────────────
@@ -45,7 +45,7 @@
                         let company: Company
                     }
                     """
-                } matches: {
+                } expansion: {
                     """
                     struct A {
                         let brand: Brand
@@ -74,7 +74,7 @@
                         let company: Company
                     }
                     """
-                } matches: {
+                } expansion: {
                     """
                     struct A: Encodable {
                         let brand: Brand
@@ -99,7 +99,7 @@
                         let company: Company
                     }
                     """
-                } matches: {
+                } expansion: {
                     """
                     struct A {
                         let brand: Brand?
@@ -128,7 +128,7 @@
                         let company: Company
                     }
                     """
-                } matches: {
+                } expansion: {
                     """
                     struct A: Decodable {
                         let brand: Brand
@@ -152,7 +152,7 @@
                         let company: Company
                     }
                     """
-                } matches: {
+                } expansion: {
                     """
                     struct A: Codable {
                         let brand: Brand
@@ -169,7 +169,7 @@
                         let company: Company
                     }
                     """
-                } matches: {
+                } expansion: {
                     """
                     public struct A {
                         let brand: Brand
@@ -198,7 +198,7 @@
                         let company: Company
                     }
                     """
-                } matches: {
+                } expansion: {
                     """
                     private struct A {
                         let brand: Brand
@@ -228,7 +228,7 @@
                         let company: Company
                     }
                     """
-                } matches: {
+                } expansion: {
                     """
                     private struct A {
                         let brand: Brand
@@ -257,7 +257,7 @@
                         let company: Company
                     }
                     """
-                } matches: {
+                } expansion: {
                     """
                     private struct A {
                         let brand: Brand
@@ -288,7 +288,7 @@
                     @AllOfDecodable
                     enum A {}
                     """
-                } matches: {
+                } diagnostics: {
                     """
                     @AllOfDecodable
                     ┬──────────────
@@ -305,7 +305,7 @@
                         let company: Company
                     }
                     """
-                } matches: {
+                } expansion: {
                     """
                     struct A {
                         let brand: Brand
@@ -330,7 +330,7 @@
                         let company: Company
                     }
                     """
-                } matches: {
+                } expansion: {
                     """
                     struct A: Encodable {
                         let brand: Brand
@@ -355,7 +355,7 @@
                         let company: Company
                     }
                     """
-                } matches: {
+                } expansion: {
                     """
                     struct A: Decodable {
                         let brand: Brand
@@ -372,7 +372,7 @@
                         let company: Company
                     }
                     """
-                } matches: {
+                } expansion: {
                     """
                     struct A: Codable {
                         let brand: Brand
@@ -389,7 +389,7 @@
                         let company: Company
                     }
                     """
-                } matches: {
+                } expansion: {
                     """
                     public struct A {
                         let brand: Brand
@@ -414,7 +414,7 @@
                         let company: Company
                     }
                     """
-                } matches: {
+                } expansion: {
                     """
                     private struct A {
                         let brand: Brand
@@ -440,7 +440,7 @@
                         let company: Company
                     }
                     """
-                } matches: {
+                } expansion: {
                     """
                     private struct A {
                         let brand: Brand
@@ -466,7 +466,7 @@
                         let company: Company
                     }
                     """
-                } matches: {
+                } expansion: {
                     """
                     private struct A {
                         let brand: Brand
@@ -495,7 +495,7 @@
                     @AllOfEncodable
                     enum A {}
                     """
-                } matches: {
+                } diagnostics: {
                     """
                     @AllOfEncodable
                     ┬──────────────
@@ -512,7 +512,7 @@
                         let company: Company
                     }
                     """
-                } matches: {
+                } expansion: {
                     """
                     struct A {
                         let brand: Brand
@@ -536,7 +536,7 @@
                         let company: Company
                     }
                     """
-                } matches: {
+                } expansion: {
                     """
                     struct A: Encodable {
                         let brand: Brand
@@ -553,7 +553,7 @@
                         let company: Company
                     }
                     """
-                } matches: {
+                } expansion: {
                     """
                     struct A: Decodable {
                         let brand: Brand
@@ -577,7 +577,7 @@
                         let company: Company
                     }
                     """
-                } matches: {
+                } expansion: {
                     """
                     struct A: Codable {
                         let brand: Brand
@@ -594,7 +594,7 @@
                         let company: Company
                     }
                     """
-                } matches: {
+                } expansion: {
                     """
                     public struct A {
                         let brand: Brand
@@ -618,7 +618,7 @@
                         let company: Company
                     }
                     """
-                } matches: {
+                } expansion: {
                     """
                     private struct A {
                         let brand: Brand
@@ -643,7 +643,7 @@
                         let company: Company
                     }
                     """
-                } matches: {
+                } expansion: {
                     """
                     private struct A {
                         let brand: Brand
@@ -668,7 +668,7 @@
                         let company: Company
                     }
                     """
-                } matches: {
+                } expansion: {
                     """
                     private struct A {
                         let brand: Brand

--- a/Tests/MacroCodableKitTests/Annotations/Macro/AnnotationsMixMacroTests.swift
+++ b/Tests/MacroCodableKitTests/Annotations/Macro/AnnotationsMixMacroTests.swift
@@ -36,7 +36,7 @@ final class AnnotationsMixMacroTests: XCTestCase {
                     let boolean2: Bool?
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 struct DefaultValueBool {
                     let boolean1: Bool

--- a/Tests/MacroCodableKitTests/Annotations/Macro/CustomCodingMacroTests.swift
+++ b/Tests/MacroCodableKitTests/Annotations/Macro/CustomCodingMacroTests.swift
@@ -32,7 +32,7 @@ final class CustomCodingMacroTests: XCTestCase {
                     let safeStrings: [String]
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 struct SafeCodingArray1: Equatable {
                     let strings: [String]
@@ -72,7 +72,7 @@ final class CustomCodingMacroTests: XCTestCase {
                     let safeStrings: [String]?
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 struct SafeCodingArray2: Equatable {
                     @CustomCoding(SafeDecoding)
@@ -109,7 +109,7 @@ final class CustomCodingMacroTests: XCTestCase {
                     let safeStringByInt: [Int: String]
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 struct SafeCodingDictionary2 {
                     let stringByInt: [Int: String]
@@ -151,7 +151,7 @@ final class CustomCodingMacroTests: XCTestCase {
                     let safeIntByString: [String: Int]?
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 struct SafeCodingDictionary3 {
                     let intByString: [String: Int]
@@ -191,7 +191,7 @@ final class CustomCodingMacroTests: XCTestCase {
                     let someType: SomeType?
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 struct SomeTypeCustomCoding {
                     @CustomCoding(XXXX)

--- a/Tests/MacroCodableKitTests/Annotations/Macro/DefaultValueMacroTests.swift
+++ b/Tests/MacroCodableKitTests/Annotations/Macro/DefaultValueMacroTests.swift
@@ -40,7 +40,7 @@ final class DefaultValueMacroTests: XCTestCase {
                     let boolean5: Bool?
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 struct DefaultValueBool {
                     let boolean1: Bool
@@ -109,7 +109,7 @@ final class DefaultValueMacroTests: XCTestCase {
                     let int4: Int?
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 struct DefaultValueInt {
                     let int1: Int
@@ -167,7 +167,7 @@ final class DefaultValueMacroTests: XCTestCase {
                     let string: String
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 struct A {
                     let int1: Bool

--- a/Tests/MacroCodableKitTests/Annotations/Macro/ValueStrategyMacroTests.swift
+++ b/Tests/MacroCodableKitTests/Annotations/Macro/ValueStrategyMacroTests.swift
@@ -35,7 +35,7 @@ final class ValueStrategyMacroTests: XCTestCase {
                     let data: Data?
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 struct Base64Struct {
                     let data: Data

--- a/Tests/MacroCodableKitTests/Codable/CodableMacroTests.swift
+++ b/Tests/MacroCodableKitTests/Codable/CodableMacroTests.swift
@@ -28,7 +28,7 @@ final class CodableMacroTests: XCTestCase {
                 @Codable
                 enum A {}
                 """
-            } matches: {
+            } diagnostics: {
                 """
                 @Codable
                 ┬───────
@@ -45,7 +45,7 @@ final class CodableMacroTests: XCTestCase {
                     let company: Company
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 struct A: Encodable {
                     let brand: Brand
@@ -74,7 +74,7 @@ final class CodableMacroTests: XCTestCase {
                     let company: Company
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 struct A: Decodable {
                     let brand: Brand
@@ -103,7 +103,7 @@ final class CodableMacroTests: XCTestCase {
                     let company: Company
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 struct A: Codable {
                     let brand: Brand
@@ -120,7 +120,7 @@ final class CodableMacroTests: XCTestCase {
                     let company: Company
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 struct A: Encodable, Decodable {
                     let brand: Brand
@@ -138,7 +138,7 @@ final class CodableMacroTests: XCTestCase {
                     let company: Company
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 private struct A {
                     let brand: Brand
@@ -170,7 +170,7 @@ final class CodableMacroTests: XCTestCase {
                     let company: Company
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 public struct A {
                     let brand: Brand
@@ -206,7 +206,7 @@ final class CodableMacroTests: XCTestCase {
                     let company: Company
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 internal struct A: Encodable {
                     let brand: Brand?
@@ -233,7 +233,7 @@ final class CodableMacroTests: XCTestCase {
                     let company: Company
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 public struct A {
                     var string: String { "" }
@@ -265,7 +265,7 @@ final class CodableMacroTests: XCTestCase {
                     var string2: String { "" }
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 public struct A {
                     var string1: String { "" }
@@ -301,7 +301,7 @@ final class CodableMacroTests: XCTestCase {
                 @Encodable
                 enum A {}
                 """
-            } matches: {
+            } diagnostics: {
                 """
                 @Encodable
                 ┬─────────
@@ -318,7 +318,7 @@ final class CodableMacroTests: XCTestCase {
                     let company: Company
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 struct A: Encodable {
                     let brand: Brand
@@ -335,7 +335,7 @@ final class CodableMacroTests: XCTestCase {
                     let company: Company
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 struct A: Decodable {
                     let brand: Brand
@@ -364,7 +364,7 @@ final class CodableMacroTests: XCTestCase {
                     let company: Company
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 struct A: Codable {
                     let brand: Brand
@@ -381,7 +381,7 @@ final class CodableMacroTests: XCTestCase {
                     let company: Company
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 struct A: Encodable, Decodable {
                     let brand: Brand
@@ -399,7 +399,7 @@ final class CodableMacroTests: XCTestCase {
                     let company: Company
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 private struct A {
                     let brand: Brand
@@ -427,7 +427,7 @@ final class CodableMacroTests: XCTestCase {
                     let company: Company
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 public struct A {
                     let brand: Brand
@@ -458,7 +458,7 @@ final class CodableMacroTests: XCTestCase {
                     let company: Company
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 internal struct A: Encodable {
                     let brand: Brand?
@@ -483,7 +483,7 @@ final class CodableMacroTests: XCTestCase {
                 @Decodable
                 enum A {}
                 """
-            } matches: {
+            } diagnostics: {
                 """
                 @Decodable
                 ┬─────────
@@ -500,7 +500,7 @@ final class CodableMacroTests: XCTestCase {
                     let company: Company
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 struct A: Encodable {
                     let brand: Brand
@@ -529,7 +529,7 @@ final class CodableMacroTests: XCTestCase {
                     let company: Company
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 struct A: Decodable {
                     let brand: Brand
@@ -546,7 +546,7 @@ final class CodableMacroTests: XCTestCase {
                     let company: Company
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 struct A: Codable {
                     let brand: Brand
@@ -563,7 +563,7 @@ final class CodableMacroTests: XCTestCase {
                     let company: Company
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 struct A: Encodable, Decodable {
                     let brand: Brand
@@ -581,7 +581,7 @@ final class CodableMacroTests: XCTestCase {
                     let company: Company
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 private struct A {
                     let brand: Brand
@@ -609,7 +609,7 @@ final class CodableMacroTests: XCTestCase {
                     let company: Company
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 public struct A {
                     let brand: Brand
@@ -639,7 +639,7 @@ final class CodableMacroTests: XCTestCase {
                     let company: Company
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 internal struct A: Encodable {
                     let brand: Brand?
@@ -679,7 +679,7 @@ final class CodableMacroTests: XCTestCase {
                     let company: Company
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 struct A: Encodable {
                     @available(*, iOS)

--- a/Tests/MacroCodableKitTests/OneOfCodable/OneOfMacroTests.swift
+++ b/Tests/MacroCodableKitTests/OneOfCodable/OneOfMacroTests.swift
@@ -26,7 +26,7 @@ final class OneOfMacroTests: XCTestCase {
                 @OneOfCodable
                 struct A {}
                 """
-            } matches: {
+            } diagnostics: {
                 """
                 @OneOfCodable
                 ┬────────────
@@ -44,7 +44,7 @@ final class OneOfMacroTests: XCTestCase {
                     case string(String)
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 enum A: Encodable {
                     case int(Int)
@@ -87,7 +87,7 @@ final class OneOfMacroTests: XCTestCase {
                     case string(String)
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 enum A: Decodable {
                     case int(Int)
@@ -125,7 +125,7 @@ final class OneOfMacroTests: XCTestCase {
                     case string(String)
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 enum A: Codable {
                     case int(Int)
@@ -144,7 +144,7 @@ final class OneOfMacroTests: XCTestCase {
                     case string(String)
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 enum A: Encodable, Decodable {
                     case int(Int)
@@ -163,7 +163,7 @@ final class OneOfMacroTests: XCTestCase {
                     case string(String)
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 private enum A {
                     case int(Int)
@@ -217,7 +217,7 @@ final class OneOfMacroTests: XCTestCase {
                     case string(String)
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 public enum A {
                     case int(Int)
@@ -276,7 +276,7 @@ final class OneOfMacroTests: XCTestCase {
                 @OneOfDecodable
                 struct A {}
                 """
-            } matches: {
+            } diagnostics: {
                 """
                 @OneOfDecodable
                 ┬──────────────
@@ -294,7 +294,7 @@ final class OneOfMacroTests: XCTestCase {
                     case string(String)
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 enum A: Encodable {
                     case int(Int)
@@ -337,7 +337,7 @@ final class OneOfMacroTests: XCTestCase {
                     case string(String)
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 enum A: Decodable {
                     case int(Int)
@@ -356,7 +356,7 @@ final class OneOfMacroTests: XCTestCase {
                     case string(String)
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 enum A: Codable {
                     case int(Int)
@@ -375,7 +375,7 @@ final class OneOfMacroTests: XCTestCase {
                     case string(String)
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 enum A: Encodable, Decodable {
                     case int(Int)
@@ -394,7 +394,7 @@ final class OneOfMacroTests: XCTestCase {
                     case string(String)
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 private enum A {
                     case int(Int)
@@ -437,7 +437,7 @@ final class OneOfMacroTests: XCTestCase {
                     case string(String)
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 public enum A {
                     case int(Int)
@@ -485,7 +485,7 @@ final class OneOfMacroTests: XCTestCase {
                 @OneOfEncodable
                 struct A {}
                 """
-            } matches: {
+            } diagnostics: {
                 """
                 @OneOfEncodable
                 ┬──────────────
@@ -503,7 +503,7 @@ final class OneOfMacroTests: XCTestCase {
                     case string(String)
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 enum A: Encodable {
                     case int(Int)
@@ -522,7 +522,7 @@ final class OneOfMacroTests: XCTestCase {
                     case string(String)
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 enum A: Decodable {
                     case int(Int)
@@ -560,7 +560,7 @@ final class OneOfMacroTests: XCTestCase {
                     case string(String)
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 enum A: Codable {
                     case int(Int)
@@ -579,7 +579,7 @@ final class OneOfMacroTests: XCTestCase {
                     case string(String)
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 enum A: Encodable, Decodable {
                     case int(Int)
@@ -598,7 +598,7 @@ final class OneOfMacroTests: XCTestCase {
                     case string(String)
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 private enum A {
                     case int(Int)
@@ -636,7 +636,7 @@ final class OneOfMacroTests: XCTestCase {
                     case string(String)
                 }
                 """
-            } matches: {
+            } expansion: {
                 """
                 public enum A {
                     case int(Int)


### PR DESCRIPTION
Pointing version with branches is not the best option, so here's `from:` instead