### PR TITLE
Rely on macro api in terms of conformances to make

### DIFF
--- a/Sources/Macro/Helpers/Conformance+Helpers.swift
+++ b/Sources/Macro/Helpers/Conformance+Helpers.swift
@@ -8,11 +8,38 @@
 import SwiftSyntax
 
 extension Conformance {
-    static func makeConformances(declaration: some DeclGroupSyntax) -> Set<Conformance> {
+    private static func makeConformances(declaration: some DeclGroupSyntax) -> Set<Conformance> {
         let inheritedTypeDescriptions = declaration.inheritanceClause?.inheritedTypes
             .map { inheritedType in
                 inheritedType.type.trimmedDescription
             } ?? []
         return Conformance.makeConformances(inheritedTypeDescriptions)
+    }
+
+    private static func makeConformances(protocols: [TypeSyntax]) -> Set<Conformance> {
+        var result = Set<Conformance>()
+        // Macro can return ['EncodableDecodable'] instead of ['Encodable', 'Decodable']
+        if protocols.contains(where: { $0.trimmedDescription.contains(Conformance.Decodable.rawValue) }) {
+            result.insert(.Decodable)
+        }
+        if protocols.contains(where: { $0.trimmedDescription.contains(Conformance.Encodable.rawValue) }) {
+            result.insert(.Encodable)
+        }
+        return result
+    }
+
+    /// Macros in testing won't provide protocols property, whereas in real project they will be provided. As a result, it's impossible to test macros behaviour
+    /// As a workaround in tests consider all conformances are declared at type
+    static func makeConformances(
+        protocols: [TypeSyntax],
+        declaration: some DeclGroupSyntax,
+        type: some TypeSyntaxProtocol,
+        expectedConformances: Set<Conformance>
+    ) -> Set<Conformance> {
+        if type.trimmedDescription.hasSuffix("__testing__") {
+            return expectedConformances.subtracting(makeConformances(declaration: declaration))
+        } else {
+            return makeConformances(protocols: protocols)
+        }
     }
 }

--- a/Sources/Macro/Macro/AllOfCodable/AllOfCodable.swift
+++ b/Sources/Macro/Macro/AllOfCodable/AllOfCodable.swift
@@ -17,17 +17,17 @@ extension AllOfCodableMacro: ExtensionMacro {
         of node: AttributeSyntax,
         attachedTo declaration: some DeclGroupSyntax,
         providingExtensionsOf type: some TypeSyntaxProtocol,
-        conformingTo _: [TypeSyntax],
+        conformingTo protocols: [TypeSyntax],
         in context: some MacroExpansionContext
     ) throws -> [ExtensionDeclSyntax] {
         try withMacro(Self.self, in: context) {
-            let existingConformances = Conformance.makeConformances(declaration: declaration)
-            let neededConformances = expectedConformances.subtracting(existingConformances)
+            let conformancesToGenerate = Conformance.makeConformances(protocols: protocols, declaration: declaration, type: type, expectedConformances: expectedConformances)
             return try AllOfMacroBase.expansion(
                 of: node,
                 attachedTo: declaration,
                 providingExtensionsOf: type,
-                conformingTo: neededConformances.map { TypeSyntax(stringLiteral: $0.rawValue) },
+                conformancesToGenerate: conformancesToGenerate,
+                expectedConformances: expectedConformances,
                 in: context
             )
         }

--- a/Sources/Macro/Macro/AllOfCodable/AllOfDecodableMacro.swift
+++ b/Sources/Macro/Macro/AllOfCodable/AllOfDecodableMacro.swift
@@ -17,17 +17,17 @@ extension AllOfDecodableMacro: ExtensionMacro {
         of node: AttributeSyntax,
         attachedTo declaration: some DeclGroupSyntax,
         providingExtensionsOf type: some TypeSyntaxProtocol,
-        conformingTo _: [TypeSyntax],
+        conformingTo protocols: [TypeSyntax],
         in context: some MacroExpansionContext
     ) throws -> [ExtensionDeclSyntax] {
         try withMacro(Self.self, in: context) {
-            let existingConformances = Conformance.makeConformances(declaration: declaration)
-            let neededConformances = expectedConformances.subtracting(existingConformances)
+            let conformancesToGenerate = Conformance.makeConformances(protocols: protocols, declaration: declaration, type: type, expectedConformances: expectedConformances)
             return try AllOfMacroBase.expansion(
                 of: node,
                 attachedTo: declaration,
                 providingExtensionsOf: type,
-                conformingTo: neededConformances.map { TypeSyntax(stringLiteral: $0.rawValue) },
+                conformancesToGenerate: conformancesToGenerate,
+                expectedConformances: expectedConformances,
                 in: context
             )
         }

--- a/Sources/Macro/Macro/AllOfCodable/AllOfEncodableMacro.swift
+++ b/Sources/Macro/Macro/AllOfCodable/AllOfEncodableMacro.swift
@@ -17,17 +17,17 @@ extension AllOfEncodableMacro: ExtensionMacro {
         of node: AttributeSyntax,
         attachedTo declaration: some DeclGroupSyntax,
         providingExtensionsOf type: some TypeSyntaxProtocol,
-        conformingTo _: [TypeSyntax],
+        conformingTo protocols: [TypeSyntax],
         in context: some MacroExpansionContext
     ) throws -> [ExtensionDeclSyntax] {
         try withMacro(Self.self, in: context) {
-            let existingConformances = Conformance.makeConformances(declaration: declaration)
-            let neededConformances = expectedConformances.subtracting(existingConformances)
+            let conformancesToGenerate = Conformance.makeConformances(protocols: protocols, declaration: declaration, type: type, expectedConformances: expectedConformances)
             return try AllOfMacroBase.expansion(
                 of: node,
                 attachedTo: declaration,
                 providingExtensionsOf: type,
-                conformingTo: neededConformances.map { TypeSyntax(stringLiteral: $0.rawValue) },
+                conformancesToGenerate: conformancesToGenerate,
+                expectedConformances: expectedConformances,
                 in: context
             )
         }

--- a/Sources/Macro/Macro/Codable/CodableMacro.swift
+++ b/Sources/Macro/Macro/Codable/CodableMacro.swift
@@ -17,17 +17,17 @@ extension CodableMacro: ExtensionMacro {
         of node: AttributeSyntax,
         attachedTo declaration: some DeclGroupSyntax,
         providingExtensionsOf type: some TypeSyntaxProtocol,
-        conformingTo _: [TypeSyntax],
+        conformingTo protocols: [TypeSyntax],
         in context: some MacroExpansionContext
     ) throws -> [ExtensionDeclSyntax] {
         try withMacro(Self.self, in: context) {
-            let existingConformances = Conformance.makeConformances(declaration: declaration)
-            let neededConformances = expectedConformances.subtracting(existingConformances)
+            let conformancesToGenerate = Conformance.makeConformances(protocols: protocols, declaration: declaration, type: type, expectedConformances: expectedConformances)
             return try CodableMacroBase.expansion(
                 of: node,
                 attachedTo: declaration,
                 providingExtensionsOf: type,
-                conformingTo: neededConformances.map { TypeSyntax(stringLiteral: $0.rawValue) },
+                conformancesToGenerate: conformancesToGenerate,
+                expectedConformances: expectedConformances,
                 in: context
             )
         }

--- a/Sources/Macro/Macro/Codable/CodableMacroBase.swift
+++ b/Sources/Macro/Macro/Codable/CodableMacroBase.swift
@@ -16,22 +16,37 @@ struct CodableMacroBase {
         of _: AttributeSyntax,
         attachedTo declaration: some DeclGroupSyntax,
         providingExtensionsOf type: some TypeSyntaxProtocol,
-        conformingTo protocols: [TypeSyntax],
+        conformancesToGenerate: Set<Conformance>,
+        expectedConformances: Set<Conformance>,
         in context: some MacroExpansionContext
     ) throws -> [ExtensionDeclSyntax] {
+        let checker = ConformanceDiagnosticChecker(
+            config: ConformanceDiagnosticChecker.Config(
+                replacementMacroName: [
+                    .Decodable: "@\(MacroConfiguration.makeName(macro: EncodableMacro.self))",
+                    .Encodable: "@\(MacroConfiguration.makeName(macro: DecodableMacro.self))"
+                ]
+            )
+        )
+        try checker.verify(
+            type: type,
+            declaration: declaration,
+            expectedConformances: expectedConformances,
+            conformancesToGenerate: conformancesToGenerate
+        )
+
         let expander = InstanceExpander(codableFactory: DefaultCodableBuilderFactoryImpl(strategy: .codingKeys))
-        let conformances = Conformance.makeConformances(protocols.map(\.trimmedDescription))
 
         let buildingData: CodableBuildingData
         do {
-            buildingData = try expander.verify(declaration: declaration, strategy: .codingKeys, conformances: conformances)
+            buildingData = try expander.verify(declaration: declaration, strategy: .codingKeys, conformances: conformancesToGenerate)
         } catch {
             return []
         }
 
         let formattedCode: String
         do {
-            let codeBuilder = expander.extensionCodeBuilder(type: type, buildingData: buildingData, conformances: conformances)
+            let codeBuilder = expander.extensionCodeBuilder(type: type, buildingData: buildingData, conformances: conformancesToGenerate)
             formattedCode = try expander.generateAndFormat(codeBuilder: codeBuilder)
         } catch {
             context.diagnose(

--- a/Sources/Macro/Macro/Codable/DecodableMacro.swift
+++ b/Sources/Macro/Macro/Codable/DecodableMacro.swift
@@ -17,17 +17,17 @@ extension DecodableMacro: ExtensionMacro {
         of node: AttributeSyntax,
         attachedTo declaration: some DeclGroupSyntax,
         providingExtensionsOf type: some TypeSyntaxProtocol,
-        conformingTo _: [TypeSyntax],
+        conformingTo protocols: [TypeSyntax],
         in context: some MacroExpansionContext
     ) throws -> [ExtensionDeclSyntax] {
         try withMacro(Self.self, in: context) {
-            let existingConformances = Conformance.makeConformances(declaration: declaration)
-            let neededConformances = expectedConformances.subtracting(existingConformances)
+            let conformancesToGenerate = Conformance.makeConformances(protocols: protocols, declaration: declaration, type: type, expectedConformances: expectedConformances)
             return try CodableMacroBase.expansion(
                 of: node,
                 attachedTo: declaration,
                 providingExtensionsOf: type,
-                conformingTo: neededConformances.map { TypeSyntax(stringLiteral: $0.rawValue) },
+                conformancesToGenerate: conformancesToGenerate,
+                expectedConformances: expectedConformances,
                 in: context
             )
         }

--- a/Sources/Macro/Macro/Codable/EncodableMacro.swift
+++ b/Sources/Macro/Macro/Codable/EncodableMacro.swift
@@ -17,17 +17,17 @@ extension EncodableMacro: ExtensionMacro {
         of node: AttributeSyntax,
         attachedTo declaration: some DeclGroupSyntax,
         providingExtensionsOf type: some TypeSyntaxProtocol,
-        conformingTo _: [TypeSyntax],
+        conformingTo protocols: [TypeSyntax],
         in context: some MacroExpansionContext
     ) throws -> [ExtensionDeclSyntax] {
         try withMacro(Self.self, in: context) {
-            let existingConformances = Conformance.makeConformances(declaration: declaration)
-            let neededConformances = expectedConformances.subtracting(existingConformances)
+            let conformancesToGenerate = Conformance.makeConformances(protocols: protocols, declaration: declaration, type: type, expectedConformances: expectedConformances)
             return try CodableMacroBase.expansion(
                 of: node,
                 attachedTo: declaration,
                 providingExtensionsOf: type,
-                conformingTo: neededConformances.map { TypeSyntax(stringLiteral: $0.rawValue) },
+                conformancesToGenerate: conformancesToGenerate,
+                expectedConformances: expectedConformances,
                 in: context
             )
         }

--- a/Sources/Macro/Macro/OneOfCodable/OneOfCodable.swift
+++ b/Sources/Macro/Macro/OneOfCodable/OneOfCodable.swift
@@ -17,17 +17,17 @@ extension OneOfCodableMacro: ExtensionMacro {
         of node: AttributeSyntax,
         attachedTo declaration: some DeclGroupSyntax,
         providingExtensionsOf type: some TypeSyntaxProtocol,
-        conformingTo _: [TypeSyntax],
+        conformingTo protocols: [TypeSyntax],
         in context: some MacroExpansionContext
     ) throws -> [ExtensionDeclSyntax] {
         try withMacro(Self.self, in: context) {
-            let existingConformances = Conformance.makeConformances(declaration: declaration)
-            let neededConformances = expectedConformances.subtracting(existingConformances)
+            let conformancesToGenerate = Conformance.makeConformances(protocols: protocols, declaration: declaration, type: type, expectedConformances: expectedConformances)
             return try OneOfMacroBase.expansion(
                 of: node,
                 attachedTo: declaration,
                 providingExtensionsOf: type,
-                conformingTo: neededConformances.map { TypeSyntax(stringLiteral: $0.rawValue) },
+                conformancesToGenerate: conformancesToGenerate,
+                expectedConformances: expectedConformances,
                 in: context
             )
         }

--- a/Sources/Macro/Macro/OneOfCodable/OneOfDecodable.swift
+++ b/Sources/Macro/Macro/OneOfCodable/OneOfDecodable.swift
@@ -17,17 +17,17 @@ extension OneOfDecodableMacro: ExtensionMacro {
         of node: AttributeSyntax,
         attachedTo declaration: some DeclGroupSyntax,
         providingExtensionsOf type: some TypeSyntaxProtocol,
-        conformingTo _: [TypeSyntax],
+        conformingTo protocols: [TypeSyntax],
         in context: some MacroExpansionContext
     ) throws -> [ExtensionDeclSyntax] {
         try withMacro(Self.self, in: context) {
-            let existingConformances = Conformance.makeConformances(declaration: declaration)
-            let neededConformances = expectedConformances.subtracting(existingConformances)
+            let conformancesToGenerate = Conformance.makeConformances(protocols: protocols, declaration: declaration, type: type, expectedConformances: expectedConformances)
             return try OneOfMacroBase.expansion(
                 of: node,
                 attachedTo: declaration,
                 providingExtensionsOf: type,
-                conformingTo: neededConformances.map { TypeSyntax(stringLiteral: $0.rawValue) },
+                conformancesToGenerate: conformancesToGenerate,
+                expectedConformances: expectedConformances,
                 in: context
             )
         }

--- a/Sources/Macro/Macro/OneOfCodable/OneOfEncodable.swift
+++ b/Sources/Macro/Macro/OneOfCodable/OneOfEncodable.swift
@@ -17,17 +17,17 @@ extension OneOfEncodableMacro: ExtensionMacro {
         of node: AttributeSyntax,
         attachedTo declaration: some DeclGroupSyntax,
         providingExtensionsOf type: some TypeSyntaxProtocol,
-        conformingTo _: [TypeSyntax],
+        conformingTo protocols: [TypeSyntax],
         in context: some MacroExpansionContext
     ) throws -> [ExtensionDeclSyntax] {
         try withMacro(Self.self, in: context) {
-            let existingConformances = Conformance.makeConformances(declaration: declaration)
-            let neededConformances = expectedConformances.subtracting(existingConformances)
+            let conformancesToGenerate = Conformance.makeConformances(protocols: protocols, declaration: declaration, type: type, expectedConformances: expectedConformances)
             return try OneOfMacroBase.expansion(
                 of: node,
                 attachedTo: declaration,
                 providingExtensionsOf: type,
-                conformingTo: neededConformances.map { TypeSyntax(stringLiteral: $0.rawValue) },
+                conformancesToGenerate: conformancesToGenerate,
+                expectedConformances: expectedConformances,
                 in: context
             )
         }

--- a/Sources/Macro/Macro/OneOfCodable/OneOfMacroBase.swift
+++ b/Sources/Macro/Macro/OneOfCodable/OneOfMacroBase.swift
@@ -16,22 +16,37 @@ public enum OneOfMacroBase {
         of _: AttributeSyntax,
         attachedTo declaration: some DeclGroupSyntax,
         providingExtensionsOf type: some TypeSyntaxProtocol,
-        conformingTo protocols: [TypeSyntax],
+        conformancesToGenerate: Set<Conformance>,
+        expectedConformances: Set<Conformance>,
         in context: some MacroExpansionContext
     ) throws -> [ExtensionDeclSyntax] {
+        let checker = ConformanceDiagnosticChecker(
+            config: ConformanceDiagnosticChecker.Config(
+                replacementMacroName: [
+                    .Decodable: "@\(MacroConfiguration.makeName(macro: OneOfEncodableMacro.self))",
+                    .Encodable: "@\(MacroConfiguration.makeName(macro: OneOfDecodableMacro.self))"
+                ]
+            )
+        )
+        try checker.verify(
+            type: type,
+            declaration: declaration,
+            expectedConformances: expectedConformances,
+            conformancesToGenerate: conformancesToGenerate
+        )
+
         let expander = Expander()
-        let conformances = Conformance.makeConformances(protocols.map(\.trimmedDescription))
 
         let buildingData: CodableBuildingData
         do {
-            buildingData = try expander.verify(declaration: declaration, conformances: conformances)
+            buildingData = try expander.verify(declaration: declaration, conformances: conformancesToGenerate)
         } catch {
             return []
         }
 
         let formattedCode: String
         do {
-            let codeBuilder = expander.extensionCodeBuilder(type: type, buildingData: buildingData, conformances: conformances)
+            let codeBuilder = expander.extensionCodeBuilder(type: type, buildingData: buildingData, conformances: conformancesToGenerate)
             formattedCode = try expander.generateAndFormat(codeBuilder: codeBuilder)
         } catch {
             context.diagnose(

--- a/Sources/Macro/Misc/Conformance.swift
+++ b/Sources/Macro/Misc/Conformance.swift
@@ -7,7 +7,7 @@
 
 import SwiftSyntax
 
-enum Conformance: String {
+enum Conformance: String, CaseIterable {
     case Codable, Encodable, Decodable
 
     public static let aliases: [Conformance: Set<Conformance>] = [

--- a/Sources/Macro/Misc/ConformanceDiagnosticChecker.swift
+++ b/Sources/Macro/Misc/ConformanceDiagnosticChecker.swift
@@ -1,0 +1,79 @@
+//
+//  ConformanceDiagnosticChecker.swift
+//
+//
+//  Created by Mikhail Maslo on 08.10.23.
+//
+
+import MacroToolkit
+import SwiftSyntax
+
+final class ConformanceDiagnosticChecker {
+    struct Config {
+        let replacementMacroName: [Conformance: String]
+
+        init(replacementMacroName: [Conformance: String]) {
+            self.replacementMacroName = replacementMacroName
+        }
+    }
+
+    private let config: Config
+
+    init(config: Config) {
+        self.config = config
+    }
+
+    func verify(
+        type: some TypeSyntaxProtocol,
+        declaration: some DeclGroupSyntax,
+        expectedConformances: Set<Conformance>,
+        conformancesToGenerate: Set<Conformance>
+    ) throws {
+        if expectedConformances == conformancesToGenerate {
+            return
+        }
+
+        guard !conformancesToGenerate.isEmpty else {
+            notifyEmptyConformances(type: type, declaration: declaration, expectedConformances: expectedConformances)
+
+            return
+        }
+
+        for conformance in Conformance.allCases
+            where expectedConformances.contains(conformance)
+                && !conformancesToGenerate.contains(conformance)
+        {
+            notifyConformanceMismatch(type: type, declaration: declaration, existingConformance: conformance)
+        }
+    }
+
+    private func notifyConformanceMismatch(
+        type: some TypeSyntaxProtocol,
+        declaration: some DeclGroupSyntax,
+        existingConformance: Conformance
+    ) {
+        let message = SimpleDiagnosticMessage(
+            message: "'@\(MacroConfiguration.current.name)' macro won't generate '\(existingConformance)' conformance since '\(type.trimmedDescription)' already conformes to it. \(config.replacementMacroName[existingConformance].map { "Consider using '\($0)' instead" } ?? "")",
+            diagnosticID: .init(id: #function),
+            severity: .warning
+        )
+        MacroConfiguration.current.context.diagnose(
+            message.diagnose(at: declaration)
+        )
+    }
+
+    private func notifyEmptyConformances(
+        type: some TypeSyntaxProtocol,
+        declaration: some DeclGroupSyntax,
+        expectedConformances: Set<Conformance>
+    ) {
+        let message = SimpleDiagnosticMessage(
+            message: "'@\(MacroConfiguration.current.name)' macro has not effect since '\(type.trimmedDescription)' already conformes to \(expectedConformances.map(\.rawValue).sorted()). Consider removing '@\(MacroConfiguration.current.name)'",
+            diagnosticID: .init(id: #function),
+            severity: .warning
+        )
+        MacroConfiguration.current.context.diagnose(
+            message.diagnose(at: declaration)
+        )
+    }
+}

--- a/Sources/Macro/Misc/MacroCurrent.swift
+++ b/Sources/Macro/Misc/MacroCurrent.swift
@@ -32,6 +32,10 @@ struct MacroConfiguration {
 
     /// name is Macro type with dropped "Macro" suffix
     var name: String {
+        Self.makeName(macro: macro)
+    }
+
+    static func makeName(macro: Macro.Type) -> String {
         String("\(macro)".dropLast("Macro".count))
     }
 }

--- a/Tests/MacroCodableKitTests/AllOfCodable/AllOfCodableMacroTests.swift
+++ b/Tests/MacroCodableKitTests/AllOfCodable/AllOfCodableMacroTests.swift
@@ -25,33 +25,33 @@ final class AllOfCodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @AllOfCodable
-                enum NotApplicable {}
+                enum NotApplicable\(sutSuffix) {}
                 """
             } diagnostics: {
                 """
                 @AllOfCodable
                 ╰─ 🛑 '@AllOfCodable' macro can only be applied to a struct
-                enum NotApplicable {}
+                enum NotApplicable__testing__ {}
                 """
             }
 
             assertMacro {
                 """
                 @AllOfCodable
-                class NotApplicable {}
+                class NotApplicable\(sutSuffix) {}
                 """
             } diagnostics: {
                 """
                 @AllOfCodable
                 ╰─ 🛑 '@AllOfCodable' macro can only be applied to a struct
-                class NotApplicable {}
+                class NotApplicable__testing__ {}
                 """
             }
 
             assertMacro {
                 """
                 @AllOfCodable
-                struct Example {
+                struct Example\(sutSuffix) {
                     let brand: Brand?
                     let company: Company
                     @OmitCoding
@@ -62,7 +62,7 @@ final class AllOfCodableMacroTests: XCTestCase {
                 """
             } expansion: {
                 """
-                struct Example {
+                struct Example__testing__ {
                     let brand: Brand?
                     let company: Company
                     let omittedCompany: Company
@@ -70,7 +70,7 @@ final class AllOfCodableMacroTests: XCTestCase {
                     var string: String { "" }
                 }
 
-                extension Example: Decodable, Encodable {
+                extension Example__testing__: Decodable, Encodable {
                     init(from decoder: Decoder) throws {
                         let container = try decoder.singleValueContainer()
                         self.brand = try container.decodeIfPresent(Brand.self)
@@ -87,41 +87,66 @@ final class AllOfCodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @AllOfCodable
-                struct NoCodableExample {
+                struct NoCodableExample\(sutSuffix) {
                     let brand: Brand
                 }
 
                 @AllOfCodable
-                struct OnlyEncodableExample: Encodable {
+                struct OnlyEncodableExample\(sutSuffix): Encodable {
                     let brand: Brand
                 }
 
                 @AllOfCodable
-                struct OnlyDecodableExample: Decodable {
+                struct OnlyDecodableExample\(sutSuffix): Decodable {
                     let brand: Brand
                 }
 
                 @AllOfCodable
-                struct CodableExample: Codable {
+                struct CodableExample\(sutSuffix): Codable {
                     let brand: Brand
                 }
                 """
-            } expansion: {
+            } diagnostics: {
                 """
-                struct NoCodableExample {
-                    let brand: Brand
-                }
-                struct OnlyEncodableExample: Encodable {
-                    let brand: Brand
-                }
-                struct OnlyDecodableExample: Decodable {
-                    let brand: Brand
-                }
-                struct CodableExample: Codable {
+                @AllOfCodable
+                struct NoCodableExample__testing__ {
                     let brand: Brand
                 }
 
-                extension NoCodableExample: Decodable, Encodable {
+                @AllOfCodable
+                ╰─ ⚠️ '@AllOfCodable' macro won't generate 'Encodable' conformance since 'OnlyEncodableExample__testing__' already conformes to it. Consider using '@AllOfDecodable' instead
+                struct OnlyEncodableExample__testing__: Encodable {
+                    let brand: Brand
+                }
+
+                @AllOfCodable
+                ╰─ ⚠️ '@AllOfCodable' macro won't generate 'Decodable' conformance since 'OnlyDecodableExample__testing__' already conformes to it. Consider using '@AllOfEncodable' instead
+                struct OnlyDecodableExample__testing__: Decodable {
+                    let brand: Brand
+                }
+
+                @AllOfCodable
+                ╰─ ⚠️ '@AllOfCodable' macro has not effect since 'CodableExample__testing__' already conformes to ["Decodable", "Encodable"]. Consider removing '@AllOfCodable'
+                struct CodableExample__testing__: Codable {
+                    let brand: Brand
+                }
+                """
+            }expansion: {
+                """
+                struct NoCodableExample__testing__ {
+                    let brand: Brand
+                }
+                struct OnlyEncodableExample__testing__: Encodable {
+                    let brand: Brand
+                }
+                struct OnlyDecodableExample__testing__: Decodable {
+                    let brand: Brand
+                }
+                struct CodableExample__testing__: Codable {
+                    let brand: Brand
+                }
+
+                extension NoCodableExample__testing__: Decodable, Encodable {
                     init(from decoder: Decoder) throws {
                         let container = try decoder.singleValueContainer()
                         self.brand = try container.decode(Brand.self)
@@ -131,14 +156,14 @@ final class AllOfCodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension OnlyEncodableExample: Decodable {
+                extension OnlyEncodableExample__testing__: Decodable {
                     init(from decoder: Decoder) throws {
                         let container = try decoder.singleValueContainer()
                         self.brand = try container.decode(Brand.self)
                     }
                 }
 
-                extension OnlyDecodableExample: Encodable {
+                extension OnlyDecodableExample__testing__: Encodable {
                     func encode(to encoder: Encoder) throws {
                         try self.brand.encode(to: encoder)
                     }
@@ -149,46 +174,46 @@ final class AllOfCodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @AllOfCodable
-                struct Empty1 {
+                struct Empty1\(sutSuffix) {
                     @OmitCoding
                     let brand: Brand
                 }
 
                 @AllOfCodable
-                struct Empty2 {
+                struct Empty2\(sutSuffix) {
                 }
 
                 @AllOfCodable
-                struct Empty3 {
+                struct Empty3\(sutSuffix) {
                     var string: String { "" }
                 }
                 """
             } expansion: {
                 """
-                struct Empty1 {
+                struct Empty1__testing__ {
                     let brand: Brand
                 }
-                struct Empty2 {
+                struct Empty2__testing__ {
                 }
-                struct Empty3 {
+                struct Empty3__testing__ {
                     var string: String { "" }
                 }
 
-                extension Empty1: Decodable, Encodable {
+                extension Empty1__testing__: Decodable, Encodable {
                     init(from decoder: Decoder) throws {
                     }
                     func encode(to encoder: Encoder) throws {
                     }
                 }
 
-                extension Empty2: Decodable, Encodable {
+                extension Empty2__testing__: Decodable, Encodable {
                     init(from decoder: Decoder) throws {
                     }
                     func encode(to encoder: Encoder) throws {
                     }
                 }
 
-                extension Empty3: Decodable, Encodable {
+                extension Empty3__testing__: Decodable, Encodable {
                     init(from decoder: Decoder) throws {
                     }
                     func encode(to encoder: Encoder) throws {
@@ -200,39 +225,39 @@ final class AllOfCodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @AllOfCodable
-                struct NoPublicCodable1 {
+                struct NoPublicCodable1\(sutSuffix) {
                     let brand: Brand
                 }
 
                 @AllOfCodable
-                private struct NoPublicCodable2 {
+                private struct NoPublicCodable2\(sutSuffix) {
                     let brand: Brand
                 }
 
                 @AllOfCodable
-                internal struct NoPublicCodable3 {
+                internal struct NoPublicCodable3\(sutSuffix) {
                     let brand: Brand
                 }
 
                 @AllOfCodable
-                public struct WithPublicCodable {
+                public struct WithPublicCodable\(sutSuffix) {
                 }
                 """
             } expansion: {
                 """
-                struct NoPublicCodable1 {
+                struct NoPublicCodable1__testing__ {
                     let brand: Brand
                 }
-                private struct NoPublicCodable2 {
+                private struct NoPublicCodable2__testing__ {
                     let brand: Brand
                 }
-                internal struct NoPublicCodable3 {
+                internal struct NoPublicCodable3__testing__ {
                     let brand: Brand
                 }
-                public struct WithPublicCodable {
+                public struct WithPublicCodable__testing__ {
                 }
 
-                extension NoPublicCodable1: Decodable, Encodable {
+                extension NoPublicCodable1__testing__: Decodable, Encodable {
                     init(from decoder: Decoder) throws {
                         let container = try decoder.singleValueContainer()
                         self.brand = try container.decode(Brand.self)
@@ -242,7 +267,7 @@ final class AllOfCodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension NoPublicCodable2: Decodable, Encodable {
+                extension NoPublicCodable2__testing__: Decodable, Encodable {
                     init(from decoder: Decoder) throws {
                         let container = try decoder.singleValueContainer()
                         self.brand = try container.decode(Brand.self)
@@ -252,7 +277,7 @@ final class AllOfCodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension NoPublicCodable3: Decodable, Encodable {
+                extension NoPublicCodable3__testing__: Decodable, Encodable {
                     init(from decoder: Decoder) throws {
                         let container = try decoder.singleValueContainer()
                         self.brand = try container.decode(Brand.self)
@@ -262,7 +287,7 @@ final class AllOfCodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension WithPublicCodable: Decodable, Encodable {
+                extension WithPublicCodable__testing__: Decodable, Encodable {
                     public init(from decoder: Decoder) throws {
                     }
                     public func encode(to encoder: Encoder) throws {

--- a/Tests/MacroCodableKitTests/AllOfCodable/AllOfDecodableMacroTests.swift
+++ b/Tests/MacroCodableKitTests/AllOfCodable/AllOfDecodableMacroTests.swift
@@ -25,33 +25,33 @@ final class AllOfDecodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @AllOfDecodable
-                enum NotApplicable {}
+                enum NotApplicable\(sutSuffix) {}
                 """
             } diagnostics: {
                 """
                 @AllOfDecodable
                 ╰─ 🛑 '@AllOfDecodable' macro can only be applied to a struct
-                enum NotApplicable {}
+                enum NotApplicable__testing__ {}
                 """
             }
 
             assertMacro {
                 """
                 @AllOfDecodable
-                class NotApplicable {}
+                class NotApplicable\(sutSuffix) {}
                 """
             } diagnostics: {
                 """
                 @AllOfDecodable
                 ╰─ 🛑 '@AllOfDecodable' macro can only be applied to a struct
-                class NotApplicable {}
+                class NotApplicable__testing__ {}
                 """
             }
 
             assertMacro {
                 """
                 @AllOfDecodable
-                struct Example {
+                struct Example\(sutSuffix) {
                     let brand: Brand?
                     let company: Company
                     @OmitCoding
@@ -60,13 +60,13 @@ final class AllOfDecodableMacroTests: XCTestCase {
                 """
             } expansion: {
                 """
-                struct Example {
+                struct Example__testing__ {
                     let brand: Brand?
                     let company: Company
                     let omittedCompany: Company
                 }
 
-                extension Example: Decodable {
+                extension Example__testing__: Decodable {
                     init(from decoder: Decoder) throws {
                         let container = try decoder.singleValueContainer()
                         self.brand = try container.decodeIfPresent(Brand.self)
@@ -79,48 +79,72 @@ final class AllOfDecodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @AllOfDecodable
-                struct NoCodableExample {
+                struct NoCodableExample\(sutSuffix) {
                     let brand: Brand
                 }
 
                 @AllOfDecodable
-                struct OnlyEncodableExample: Encodable {
+                struct OnlyEncodableExample\(sutSuffix): Encodable {
                     let brand: Brand
                 }
 
                 @AllOfDecodable
-                struct OnlyDecodableExample: Decodable {
+                struct OnlyDecodableExample\(sutSuffix): Decodable {
                     let brand: Brand
                 }
 
                 @AllOfDecodable
-                struct CodableExample: Codable {
+                struct CodableExample\(sutSuffix): Codable {
+                    let brand: Brand
+                }
+                """
+            } diagnostics: {
+                """
+                @AllOfDecodable
+                struct NoCodableExample__testing__ {
+                    let brand: Brand
+                }
+
+                @AllOfDecodable
+                struct OnlyEncodableExample__testing__: Encodable {
+                    let brand: Brand
+                }
+
+                @AllOfDecodable
+                ╰─ ⚠️ '@AllOfDecodable' macro has not effect since 'OnlyDecodableExample__testing__' already conformes to ["Decodable"]. Consider removing '@AllOfDecodable'
+                struct OnlyDecodableExample__testing__: Decodable {
+                    let brand: Brand
+                }
+
+                @AllOfDecodable
+                ╰─ ⚠️ '@AllOfDecodable' macro has not effect since 'CodableExample__testing__' already conformes to ["Decodable"]. Consider removing '@AllOfDecodable'
+                struct CodableExample__testing__: Codable {
                     let brand: Brand
                 }
                 """
             } expansion: {
                 """
-                struct NoCodableExample {
+                struct NoCodableExample__testing__ {
                     let brand: Brand
                 }
-                struct OnlyEncodableExample: Encodable {
+                struct OnlyEncodableExample__testing__: Encodable {
                     let brand: Brand
                 }
-                struct OnlyDecodableExample: Decodable {
+                struct OnlyDecodableExample__testing__: Decodable {
                     let brand: Brand
                 }
-                struct CodableExample: Codable {
+                struct CodableExample__testing__: Codable {
                     let brand: Brand
                 }
 
-                extension NoCodableExample: Decodable {
+                extension NoCodableExample__testing__: Decodable {
                     init(from decoder: Decoder) throws {
                         let container = try decoder.singleValueContainer()
                         self.brand = try container.decode(Brand.self)
                     }
                 }
 
-                extension OnlyEncodableExample: Decodable {
+                extension OnlyEncodableExample__testing__: Decodable {
                     init(from decoder: Decoder) throws {
                         let container = try decoder.singleValueContainer()
                         self.brand = try container.decode(Brand.self)
@@ -132,29 +156,33 @@ final class AllOfDecodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @AllOfDecodable
-                struct Empty1 {
+                struct Empty1\(sutSuffix) {
                     @OmitCoding
                     let brand: Brand
                 }
 
                 @AllOfDecodable
-                struct Empty2 {
+                struct Empty2\(sutSuffix) {
                 }
                 """
-            } expansion: {
+            } diagnostics: {
                 """
-                struct Empty1 {
+
+                """
+            }expansion: {
+                """
+                struct Empty1__testing__ {
                     let brand: Brand
                 }
-                struct Empty2 {
+                struct Empty2__testing__ {
                 }
 
-                extension Empty1: Decodable {
+                extension Empty1__testing__: Decodable {
                     init(from decoder: Decoder) throws {
                     }
                 }
 
-                extension Empty2: Decodable {
+                extension Empty2__testing__: Decodable {
                     init(from decoder: Decoder) throws {
                     }
                 }
@@ -164,60 +192,60 @@ final class AllOfDecodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @AllOfDecodable
-                struct NoPublicCodable1 {
+                struct NoPublicCodable1\(sutSuffix) {
                     let brand: Brand
                 }
 
                 @AllOfDecodable
-                private struct NoPublicCodable2 {
+                private struct NoPublicCodable2\(sutSuffix) {
                     let brand: Brand
                 }
 
                 @AllOfDecodable
-                internal struct NoPublicCodable3 {
+                internal struct NoPublicCodable3\(sutSuffix) {
                     let brand: Brand
                 }
 
                 @AllOfDecodable
-                public struct WithPublicCodable {
+                public struct WithPublicCodable\(sutSuffix) {
                 }
                 """
             } expansion: {
                 """
-                struct NoPublicCodable1 {
+                struct NoPublicCodable1__testing__ {
                     let brand: Brand
                 }
-                private struct NoPublicCodable2 {
+                private struct NoPublicCodable2__testing__ {
                     let brand: Brand
                 }
-                internal struct NoPublicCodable3 {
+                internal struct NoPublicCodable3__testing__ {
                     let brand: Brand
                 }
-                public struct WithPublicCodable {
+                public struct WithPublicCodable__testing__ {
                 }
 
-                extension NoPublicCodable1: Decodable {
+                extension NoPublicCodable1__testing__: Decodable {
                     init(from decoder: Decoder) throws {
                         let container = try decoder.singleValueContainer()
                         self.brand = try container.decode(Brand.self)
                     }
                 }
 
-                extension NoPublicCodable2: Decodable {
+                extension NoPublicCodable2__testing__: Decodable {
                     init(from decoder: Decoder) throws {
                         let container = try decoder.singleValueContainer()
                         self.brand = try container.decode(Brand.self)
                     }
                 }
 
-                extension NoPublicCodable3: Decodable {
+                extension NoPublicCodable3__testing__: Decodable {
                     init(from decoder: Decoder) throws {
                         let container = try decoder.singleValueContainer()
                         self.brand = try container.decode(Brand.self)
                     }
                 }
 
-                extension WithPublicCodable: Decodable {
+                extension WithPublicCodable__testing__: Decodable {
                     public init(from decoder: Decoder) throws {
                     }
                 }

--- a/Tests/MacroCodableKitTests/AllOfCodable/AllOfEncodableMacroTests.swift
+++ b/Tests/MacroCodableKitTests/AllOfCodable/AllOfEncodableMacroTests.swift
@@ -25,33 +25,33 @@ final class AllOfEncodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @AllOfEncodable
-                enum NotApplicable {}
+                enum NotApplicable\(sutSuffix) {}
                 """
             } diagnostics: {
                 """
                 @AllOfEncodable
                 ╰─ 🛑 '@AllOfEncodable' macro can only be applied to a struct
-                enum NotApplicable {}
+                enum NotApplicable__testing__ {}
                 """
             }
 
             assertMacro {
                 """
                 @AllOfEncodable
-                class NotApplicable {}
+                class NotApplicable\(sutSuffix) {}
                 """
             } diagnostics: {
                 """
                 @AllOfEncodable
                 ╰─ 🛑 '@AllOfEncodable' macro can only be applied to a struct
-                class NotApplicable {}
+                class NotApplicable__testing__ {}
                 """
             }
 
             assertMacro {
                 """
                 @AllOfEncodable
-                struct Example {
+                struct Example\(sutSuffix) {
                     let brand: Brand?
                     let company: Company
                     @OmitCoding
@@ -60,13 +60,13 @@ final class AllOfEncodableMacroTests: XCTestCase {
                 """
             } expansion: {
                 """
-                struct Example {
+                struct Example__testing__ {
                     let brand: Brand?
                     let company: Company
                     let omittedCompany: Company
                 }
 
-                extension Example: Encodable {
+                extension Example__testing__: Encodable {
                     func encode(to encoder: Encoder) throws {
                         try self.brand.encodeIfPresent(to: encoder)
                         try self.company.encode(to: encoder)
@@ -78,47 +78,71 @@ final class AllOfEncodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @AllOfEncodable
-                struct NoCodableExample {
+                struct NoCodableExample\(sutSuffix) {
                     let brand: Brand
                 }
 
                 @AllOfEncodable
-                struct OnlyEncodableExample: Encodable {
+                struct OnlyEncodableExample\(sutSuffix): Encodable {
                     let brand: Brand
                 }
 
                 @AllOfEncodable
-                struct OnlyDecodableExample: Decodable {
+                struct OnlyDecodableExample\(sutSuffix): Decodable {
                     let brand: Brand
                 }
 
                 @AllOfEncodable
-                struct CodableExample: Codable {
+                struct CodableExample\(sutSuffix): Codable {
+                    let brand: Brand
+                }
+                """
+            } diagnostics: {
+                """
+                @AllOfEncodable
+                struct NoCodableExample__testing__ {
+                    let brand: Brand
+                }
+
+                @AllOfEncodable
+                ╰─ ⚠️ '@AllOfEncodable' macro has not effect since 'OnlyEncodableExample__testing__' already conformes to ["Encodable"]. Consider removing '@AllOfEncodable'
+                struct OnlyEncodableExample__testing__: Encodable {
+                    let brand: Brand
+                }
+
+                @AllOfEncodable
+                struct OnlyDecodableExample__testing__: Decodable {
+                    let brand: Brand
+                }
+
+                @AllOfEncodable
+                ╰─ ⚠️ '@AllOfEncodable' macro has not effect since 'CodableExample__testing__' already conformes to ["Encodable"]. Consider removing '@AllOfEncodable'
+                struct CodableExample__testing__: Codable {
                     let brand: Brand
                 }
                 """
             } expansion: {
                 """
-                struct NoCodableExample {
+                struct NoCodableExample__testing__ {
                     let brand: Brand
                 }
-                struct OnlyEncodableExample: Encodable {
+                struct OnlyEncodableExample__testing__: Encodable {
                     let brand: Brand
                 }
-                struct OnlyDecodableExample: Decodable {
+                struct OnlyDecodableExample__testing__: Decodable {
                     let brand: Brand
                 }
-                struct CodableExample: Codable {
+                struct CodableExample__testing__: Codable {
                     let brand: Brand
                 }
 
-                extension NoCodableExample: Encodable {
+                extension NoCodableExample__testing__: Encodable {
                     func encode(to encoder: Encoder) throws {
                         try self.brand.encode(to: encoder)
                     }
                 }
 
-                extension OnlyDecodableExample: Encodable {
+                extension OnlyDecodableExample__testing__: Encodable {
                     func encode(to encoder: Encoder) throws {
                         try self.brand.encode(to: encoder)
                     }
@@ -129,29 +153,29 @@ final class AllOfEncodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @AllOfEncodable
-                struct Empty1 {
+                struct Empty1\(sutSuffix) {
                     @OmitCoding
                     let brand: Brand
                 }
 
                 @AllOfEncodable
-                struct Empty2 {
+                struct Empty2\(sutSuffix) {
                 }
                 """
             } expansion: {
                 """
-                struct Empty1 {
+                struct Empty1__testing__ {
                     let brand: Brand
                 }
-                struct Empty2 {
+                struct Empty2__testing__ {
                 }
 
-                extension Empty1: Encodable {
+                extension Empty1__testing__: Encodable {
                     func encode(to encoder: Encoder) throws {
                     }
                 }
 
-                extension Empty2: Encodable {
+                extension Empty2__testing__: Encodable {
                     func encode(to encoder: Encoder) throws {
                     }
                 }
@@ -161,57 +185,57 @@ final class AllOfEncodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @AllOfEncodable
-                struct NoPublicCodable1 {
+                struct NoPublicCodable1\(sutSuffix) {
                     let brand: Brand
                 }
 
                 @AllOfEncodable
-                private struct NoPublicCodable2 {
+                private struct NoPublicCodable2\(sutSuffix) {
                     let brand: Brand
                 }
 
                 @AllOfEncodable
-                internal struct NoPublicCodable3 {
+                internal struct NoPublicCodable3\(sutSuffix) {
                     let brand: Brand
                 }
 
                 @AllOfEncodable
-                public struct WithPublicCodable {
+                public struct WithPublicCodable\(sutSuffix) {
                 }
                 """
             } expansion: {
                 """
-                struct NoPublicCodable1 {
+                struct NoPublicCodable1__testing__ {
                     let brand: Brand
                 }
-                private struct NoPublicCodable2 {
+                private struct NoPublicCodable2__testing__ {
                     let brand: Brand
                 }
-                internal struct NoPublicCodable3 {
+                internal struct NoPublicCodable3__testing__ {
                     let brand: Brand
                 }
-                public struct WithPublicCodable {
+                public struct WithPublicCodable__testing__ {
                 }
 
-                extension NoPublicCodable1: Encodable {
+                extension NoPublicCodable1__testing__: Encodable {
                     func encode(to encoder: Encoder) throws {
                         try self.brand.encode(to: encoder)
                     }
                 }
 
-                extension NoPublicCodable2: Encodable {
+                extension NoPublicCodable2__testing__: Encodable {
                     func encode(to encoder: Encoder) throws {
                         try self.brand.encode(to: encoder)
                     }
                 }
 
-                extension NoPublicCodable3: Encodable {
+                extension NoPublicCodable3__testing__: Encodable {
                     func encode(to encoder: Encoder) throws {
                         try self.brand.encode(to: encoder)
                     }
                 }
 
-                extension WithPublicCodable: Encodable {
+                extension WithPublicCodable__testing__: Encodable {
                     public func encode(to encoder: Encoder) throws {
                     }
                 }

--- a/Tests/MacroCodableKitTests/Annotations/Macro/AnnotationsMixMacroTests.swift
+++ b/Tests/MacroCodableKitTests/Annotations/Macro/AnnotationsMixMacroTests.swift
@@ -26,7 +26,7 @@ final class AnnotationsMixMacroTests: XCTestCase {
             assertMacro {
                 """
                 @Codable
-                struct DefaultValueBool {
+                struct DefaultValueBool\(sutSuffix) {
                     @ValueStrategy(SomeBoolStrategy)
                     @DefaultValue(BoolFalse)
                     let boolean1: Bool
@@ -38,12 +38,12 @@ final class AnnotationsMixMacroTests: XCTestCase {
                 """
             } expansion: {
                 """
-                struct DefaultValueBool {
+                struct DefaultValueBool__testing__ {
                     let boolean1: Bool
                     let boolean2: Bool?
                 }
 
-                extension DefaultValueBool: Decodable, Encodable {
+                extension DefaultValueBool__testing__: Decodable, Encodable {
                     enum CodingKeys: String, CodingKey {
                         case boolean1
                         case boolean2

--- a/Tests/MacroCodableKitTests/Annotations/Macro/CustomCodingMacroTests.swift
+++ b/Tests/MacroCodableKitTests/Annotations/Macro/CustomCodingMacroTests.swift
@@ -25,7 +25,7 @@ final class CustomCodingMacroTests: XCTestCase {
             assertMacro {
                 """
                 @Codable
-                struct SafeCodingArray1: Equatable {
+                struct SafeCodingArray1\(sutSuffix): Equatable {
                     let strings: [String]
 
                     @CustomCoding(SafeDecoding)
@@ -34,14 +34,14 @@ final class CustomCodingMacroTests: XCTestCase {
                 """
             } expansion: {
                 """
-                struct SafeCodingArray1: Equatable {
+                struct SafeCodingArray1__testing__: Equatable {
                     let strings: [String]
 
                     @CustomCoding(SafeDecoding)
                     let safeStrings: [String]
                 }
 
-                extension SafeCodingArray1: Decodable, Encodable {
+                extension SafeCodingArray1__testing__: Decodable, Encodable {
                     enum CodingKeys: String, CodingKey {
                         case strings
                         case safeStrings
@@ -67,19 +67,19 @@ final class CustomCodingMacroTests: XCTestCase {
             assertMacro {
                 """
                 @Codable
-                struct SafeCodingArray2: Equatable {
+                struct SafeCodingArray2\(sutSuffix): Equatable {
                     @CustomCoding(SafeDecoding)
                     let safeStrings: [String]?
                 }
                 """
             } expansion: {
                 """
-                struct SafeCodingArray2: Equatable {
+                struct SafeCodingArray2__testing__: Equatable {
                     @CustomCoding(SafeDecoding)
                     let safeStrings: [String]?
                 }
 
-                extension SafeCodingArray2: Decodable, Encodable {
+                extension SafeCodingArray2__testing__: Decodable, Encodable {
                     enum CodingKeys: String, CodingKey {
                         case safeStrings
                     }
@@ -102,7 +102,7 @@ final class CustomCodingMacroTests: XCTestCase {
             assertMacro {
                 """
                 @Codable
-                struct SafeCodingDictionary2 {
+                struct SafeCodingDictionary2\(sutSuffix) {
                     let stringByInt: [Int: String]
 
                     @CustomCoding(SafeDecoding)
@@ -111,14 +111,14 @@ final class CustomCodingMacroTests: XCTestCase {
                 """
             } expansion: {
                 """
-                struct SafeCodingDictionary2 {
+                struct SafeCodingDictionary2__testing__ {
                     let stringByInt: [Int: String]
 
                     @CustomCoding(SafeDecoding)
                     let safeStringByInt: [Int: String]
                 }
 
-                extension SafeCodingDictionary2: Decodable, Encodable {
+                extension SafeCodingDictionary2__testing__: Decodable, Encodable {
                     enum CodingKeys: String, CodingKey {
                         case stringByInt
                         case safeStringByInt
@@ -144,7 +144,7 @@ final class CustomCodingMacroTests: XCTestCase {
             assertMacro {
                 """
                 @Codable
-                struct SafeCodingDictionary3 {
+                struct SafeCodingDictionary3\(sutSuffix) {
                     let intByString: [String: Int]
 
                     @CustomCoding(SafeDecoding)
@@ -153,14 +153,14 @@ final class CustomCodingMacroTests: XCTestCase {
                 """
             } expansion: {
                 """
-                struct SafeCodingDictionary3 {
+                struct SafeCodingDictionary3__testing__ {
                     let intByString: [String: Int]
 
                     @CustomCoding(SafeDecoding)
                     let safeIntByString: [String: Int]?
                 }
 
-                extension SafeCodingDictionary3: Decodable, Encodable {
+                extension SafeCodingDictionary3__testing__: Decodable, Encodable {
                     enum CodingKeys: String, CodingKey {
                         case intByString
                         case safeIntByString
@@ -186,19 +186,19 @@ final class CustomCodingMacroTests: XCTestCase {
             assertMacro {
                 """
                 @Codable
-                struct SomeTypeCustomCoding {
+                struct SomeTypeCustomCoding\(sutSuffix) {
                     @CustomCoding(XXXX)
                     let someType: SomeType?
                 }
                 """
             } expansion: {
                 """
-                struct SomeTypeCustomCoding {
+                struct SomeTypeCustomCoding__testing__ {
                     @CustomCoding(XXXX)
                     let someType: SomeType?
                 }
 
-                extension SomeTypeCustomCoding: Decodable, Encodable {
+                extension SomeTypeCustomCoding__testing__: Decodable, Encodable {
                     enum CodingKeys: String, CodingKey {
                         case someType
                     }

--- a/Tests/MacroCodableKitTests/Annotations/Macro/DefaultValueMacroTests.swift
+++ b/Tests/MacroCodableKitTests/Annotations/Macro/DefaultValueMacroTests.swift
@@ -25,7 +25,7 @@ final class DefaultValueMacroTests: XCTestCase {
             assertMacro {
                 """
                 @Codable
-                struct DefaultValueBool {
+                struct DefaultValueBool\(sutSuffix) {
                     let boolean1: Bool
 
                     @DefaultValue(BoolFalse)
@@ -42,7 +42,7 @@ final class DefaultValueMacroTests: XCTestCase {
                 """
             } expansion: {
                 """
-                struct DefaultValueBool {
+                struct DefaultValueBool__testing__ {
                     let boolean1: Bool
                     let boolean2: Bool
                     let boolean3: Bool
@@ -51,7 +51,7 @@ final class DefaultValueMacroTests: XCTestCase {
                     let boolean5: Bool?
                 }
 
-                extension DefaultValueBool: Decodable, Encodable {
+                extension DefaultValueBool__testing__: Decodable, Encodable {
                     enum CodingKeys: String, CodingKey {
                         case boolean1
                         case boolean2
@@ -97,7 +97,7 @@ final class DefaultValueMacroTests: XCTestCase {
             assertMacro {
                 """
                 @Codable
-                struct DefaultValueInt {
+                struct DefaultValueInt\(sutSuffix) {
                     let int1: Int
 
                     @DefaultValue(IntZero)
@@ -111,7 +111,7 @@ final class DefaultValueMacroTests: XCTestCase {
                 """
             } expansion: {
                 """
-                struct DefaultValueInt {
+                struct DefaultValueInt__testing__ {
                     let int1: Int
                     let int2: Int
                     let int3: Int?
@@ -119,7 +119,7 @@ final class DefaultValueMacroTests: XCTestCase {
                     let int4: Int?
                 }
 
-                extension DefaultValueInt: Decodable, Encodable {
+                extension DefaultValueInt__testing__: Decodable, Encodable {
                     enum CodingKeys: String, CodingKey {
                         case int1
                         case int2
@@ -157,7 +157,7 @@ final class DefaultValueMacroTests: XCTestCase {
             assertMacro {
                 """
                 @Codable
-                struct A {
+                struct A\(sutSuffix) {
                     let int1: Bool
 
                     @DefaultValue(IntZero)
@@ -169,13 +169,13 @@ final class DefaultValueMacroTests: XCTestCase {
                 """
             } expansion: {
                 """
-                struct A {
+                struct A__testing__ {
                     let int1: Bool
                     let int2: Bool
                     let string: String
                 }
 
-                extension A: Decodable, Encodable {
+                extension A__testing__: Decodable, Encodable {
                     enum CodingKeys: String, CodingKey {
                         case int1
                         case int2

--- a/Tests/MacroCodableKitTests/Annotations/Macro/DiagnosticTests.swift
+++ b/Tests/MacroCodableKitTests/Annotations/Macro/DiagnosticTests.swift
@@ -29,7 +29,7 @@ final class DiagnosticTests: XCTestCase {
             assertMacro {
                 """
                 @Codable
-                struct Example {
+                struct Example\(sutSuffix) {
                     @OmitCoding
                     @OmitCoding
                     let a: Int
@@ -38,7 +38,7 @@ final class DiagnosticTests: XCTestCase {
             } diagnostics: {
                 """
                 @Codable
-                struct Example {
+                struct Example__testing__ {
                     @OmitCoding
                     ╰─ 🛑 '@Omitcoding' attribute has been applied more than once. Redundant attribute applications have no effect on the generated code and may cause confusion.
                     @OmitCoding
@@ -50,7 +50,7 @@ final class DiagnosticTests: XCTestCase {
             assertMacro {
                 """
                 @Codable
-                struct Example {
+                struct Example\(sutSuffix) {
                     @CodingKey("_a")
                     @CodingKey("_a")
                     let a: Int
@@ -59,7 +59,7 @@ final class DiagnosticTests: XCTestCase {
             } diagnostics: {
                 """
                 @Codable
-                struct Example {
+                struct Example__testing__ {
                     @CodingKey("_a")
                     ╰─ 🛑 '@Codingkey' attribute has been applied more than once. Redundant attribute applications have no effect on the generated code and may cause confusion.
                     @CodingKey("_a")
@@ -71,7 +71,7 @@ final class DiagnosticTests: XCTestCase {
             assertMacro {
                 """
                 @Codable
-                struct Example {
+                struct Example\(sutSuffix) {
                     @ValueStrategy(Base64Data)
                     @ValueStrategy(Base64Data)
                     let string: String
@@ -80,7 +80,7 @@ final class DiagnosticTests: XCTestCase {
             } diagnostics: {
                 """
                 @Codable
-                struct Example {
+                struct Example__testing__ {
                     @ValueStrategy(Base64Data)
                     ╰─ 🛑 '@Valuestrategy' attribute has been applied more than once. Redundant attribute applications have no effect on the generated code and may cause confusion.
                     @ValueStrategy(Base64Data)
@@ -92,7 +92,7 @@ final class DiagnosticTests: XCTestCase {
             assertMacro {
                 """
                 @Codable
-                struct Example {
+                struct Example\(sutSuffix) {
                     @DefaultValue(BoolTrue)
                     @DefaultValue(BoolFalse)
                     let bool: Bool
@@ -101,7 +101,7 @@ final class DiagnosticTests: XCTestCase {
             } diagnostics: {
                 """
                 @Codable
-                struct Example {
+                struct Example__testing__ {
                     @DefaultValue(BoolTrue)
                     ╰─ 🛑 '@Defaultvalue' attribute has been applied more than once. Redundant attribute applications have no effect on the generated code and may cause confusion.
                     @DefaultValue(BoolFalse)
@@ -113,7 +113,7 @@ final class DiagnosticTests: XCTestCase {
             assertMacro {
                 """
                 @Codable
-                struct Example {
+                struct Example\(sutSuffix) {
                     @CustomCoding(SafeDecoding)
                     @CustomCoding(SafeDecoding)
                     let array: [Bool]
@@ -122,7 +122,7 @@ final class DiagnosticTests: XCTestCase {
             } diagnostics: {
                 """
                 @Codable
-                struct Example {
+                struct Example__testing__ {
                     @CustomCoding(SafeDecoding)
                     ╰─ 🛑 '@Customcoding' attribute has been applied more than once. Redundant attribute applications have no effect on the generated code and may cause confusion.
                     @CustomCoding(SafeDecoding)
@@ -143,14 +143,14 @@ final class DiagnosticTests: XCTestCase {
             assertMacro {
                 """
                 @Codable
-                struct Example {
+                struct Example\(sutSuffix) {
                     let a, b: Int
                 }
                 """
             } diagnostics: {
                 """
                 @Codable
-                struct Example {
+                struct Example__testing__ {
                     let a, b: Int
                     ┬────────────
                     ╰─ 🛑 '@Codable' macro is only applicable to declarations with an identifier followed by a type
@@ -161,14 +161,14 @@ final class DiagnosticTests: XCTestCase {
             assertMacro {
                 """
                 @Codable
-                struct Example {
+                struct Example\(sutSuffix) {
                     let a: Int, b: Int
                 }
                 """
             } diagnostics: {
                 """
                 @Codable
-                struct Example {
+                struct Example__testing__ {
                     let a: Int, b: Int
                     ┬─────────────────
                     ╰─ 🛑 '@Codable' macro is not applicable to compound declarations, declare each variable on a new line
@@ -179,7 +179,7 @@ final class DiagnosticTests: XCTestCase {
             assertMacro {
                 """
                 @Codable
-                struct Example {
+                struct Example\(sutSuffix) {
                     @DefaultValue(IntZero)
                     var a: Int { 0 }
                 }
@@ -187,7 +187,7 @@ final class DiagnosticTests: XCTestCase {
             } diagnostics: {
                 """
                 @Codable
-                struct Example {
+                struct Example__testing__ {
                     @DefaultValue(IntZero)
                     ╰─ 🛑 '@Codable' macro is only applicable to stored properties declared with an identifier followed by a type, example: `let variable: Int`
                     var a: Int { 0 }

--- a/Tests/MacroCodableKitTests/Annotations/Macro/ValueStrategyMacroTests.swift
+++ b/Tests/MacroCodableKitTests/Annotations/Macro/ValueStrategyMacroTests.swift
@@ -25,7 +25,7 @@ final class ValueStrategyMacroTests: XCTestCase {
             assertMacro {
                 """
                 @Codable
-                struct Base64Struct {
+                struct Base64Struct\(sutSuffix) {
                     let data: Data
 
                     @ValueStrategy(Base64Data)
@@ -37,13 +37,13 @@ final class ValueStrategyMacroTests: XCTestCase {
                 """
             } expansion: {
                 """
-                struct Base64Struct {
+                struct Base64Struct__testing__ {
                     let data: Data
                     let data: Data
                     let data: Data?
                 }
 
-                extension Base64Struct: Decodable, Encodable {
+                extension Base64Struct__testing__: Decodable, Encodable {
                     enum CodingKeys: String, CodingKey {
                         case data
                         case data

--- a/Tests/MacroCodableKitTests/Codable/CodableMacroTests.swift
+++ b/Tests/MacroCodableKitTests/Codable/CodableMacroTests.swift
@@ -26,33 +26,33 @@ final class CodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @Codable
-                enum NoApplicable {}
+                enum NoApplicable\(sutSuffix) {}
                 """
             } diagnostics: {
                 """
                 @Codable
                 ╰─ 🛑 '@Codable' macro can only be applied to a struct
-                enum NoApplicable {}
+                enum NoApplicable__testing__ {}
                 """
             }
 
             assertMacro {
                 """
                 @Codable
-                class NoApplicable {}
+                class NoApplicable\(sutSuffix) {}
                 """
             } diagnostics: {
                 """
                 @Codable
                 ╰─ 🛑 '@Codable' macro can only be applied to a struct
-                class NoApplicable {}
+                class NoApplicable__testing__ {}
                 """
             }
 
             assertMacro {
                 """
                 @Codable
-                struct Example {
+                struct Example\(sutSuffix) {
                     let brand: Brand?
                     let company: Company
 
@@ -71,7 +71,7 @@ final class CodableMacroTests: XCTestCase {
                 """
             } expansion: {
                 """
-                struct Example {
+                struct Example__testing__ {
                     let brand: Brand?
                     let company: Company
                     let omittedCompany: Company
@@ -82,7 +82,7 @@ final class CodableMacroTests: XCTestCase {
                     let available: Bool
                 }
 
-                extension Example: Decodable, Encodable {
+                extension Example__testing__: Decodable, Encodable {
                     enum CodingKeys: String, CodingKey {
                         case brand
                         case company
@@ -110,41 +110,66 @@ final class CodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @Codable
-                struct NoCodableExample {
+                struct NoCodableExample\(sutSuffix) {
                     let brand: Brand
                 }
 
                 @Codable
-                struct OnlyEncodableExample: Encodable {
+                struct OnlyEncodableExample\(sutSuffix): Encodable {
                     let brand: Brand
                 }
 
                 @Codable
-                struct OnlyDecodableExample: Decodable {
+                struct OnlyDecodableExample\(sutSuffix): Decodable {
                     let brand: Brand
                 }
 
                 @Codable
-                struct CodableExample: Codable {
+                struct CodableExample\(sutSuffix): Codable {
+                    let brand: Brand
+                }
+                """
+            } diagnostics: {
+                """
+                @Codable
+                struct NoCodableExample__testing__ {
+                    let brand: Brand
+                }
+
+                @Codable
+                ╰─ ⚠️ '@Codable' macro won't generate 'Encodable' conformance since 'OnlyEncodableExample__testing__' already conformes to it. Consider using '@Decodable' instead
+                struct OnlyEncodableExample__testing__: Encodable {
+                    let brand: Brand
+                }
+
+                @Codable
+                ╰─ ⚠️ '@Codable' macro won't generate 'Decodable' conformance since 'OnlyDecodableExample__testing__' already conformes to it. Consider using '@Encodable' instead
+                struct OnlyDecodableExample__testing__: Decodable {
+                    let brand: Brand
+                }
+
+                @Codable
+                ╰─ ⚠️ '@Codable' macro has not effect since 'CodableExample__testing__' already conformes to ["Decodable", "Encodable"]. Consider removing '@Codable'
+                struct CodableExample__testing__: Codable {
                     let brand: Brand
                 }
                 """
             } expansion: {
                 """
-                struct NoCodableExample {
+                struct NoCodableExample__testing__ {
                     let brand: Brand
                 }
-                struct OnlyEncodableExample: Encodable {
+                struct OnlyEncodableExample__testing__: Encodable {
                     let brand: Brand
                 }
-                struct OnlyDecodableExample: Decodable {
+                struct OnlyDecodableExample__testing__: Decodable {
                     let brand: Brand
                 }
-                struct CodableExample: Codable {
+                struct CodableExample__testing__: Codable {
                     let brand: Brand
                 }
 
-                extension NoCodableExample: Decodable, Encodable {
+                extension NoCodableExample__testing__: Decodable, Encodable {
                     enum CodingKeys: String, CodingKey {
                         case brand
                     }
@@ -158,7 +183,7 @@ final class CodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension OnlyEncodableExample: Decodable {
+                extension OnlyEncodableExample__testing__: Decodable {
                     enum CodingKeys: String, CodingKey {
                         case brand
                     }
@@ -168,7 +193,7 @@ final class CodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension OnlyDecodableExample: Encodable {
+                extension OnlyDecodableExample__testing__: Encodable {
                     enum CodingKeys: String, CodingKey {
                         case brand
                     }
@@ -183,46 +208,46 @@ final class CodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @Codable
-                struct Empty1 {
+                struct Empty1\(sutSuffix) {
                     @OmitCoding
                     let brand: Brand
                 }
 
                 @Codable
-                struct Empty2 {
+                struct Empty2\(sutSuffix) {
                 }
 
                 @Codable
-                struct Empty3 {
+                struct Empty3\(sutSuffix) {
                     var string: String { "" }
                 }
                 """
             } expansion: {
                 """
-                struct Empty1 {
+                struct Empty1__testing__ {
                     let brand: Brand
                 }
-                struct Empty2 {
+                struct Empty2__testing__ {
                 }
-                struct Empty3 {
+                struct Empty3__testing__ {
                     var string: String { "" }
                 }
 
-                extension Empty1: Decodable, Encodable {
+                extension Empty1__testing__: Decodable, Encodable {
                     init(from decoder: Decoder) throws {
                     }
                     func encode(to encoder: Encoder) throws {
                     }
                 }
 
-                extension Empty2: Decodable, Encodable {
+                extension Empty2__testing__: Decodable, Encodable {
                     init(from decoder: Decoder) throws {
                     }
                     func encode(to encoder: Encoder) throws {
                     }
                 }
 
-                extension Empty3: Decodable, Encodable {
+                extension Empty3__testing__: Decodable, Encodable {
                     init(from decoder: Decoder) throws {
                     }
                     func encode(to encoder: Encoder) throws {
@@ -234,39 +259,39 @@ final class CodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @Codable
-                struct NoPublicCodable1 {
+                struct NoPublicCodable1\(sutSuffix) {
                     let brand: Brand
                 }
 
                 @Codable
-                private struct NoPublicCodable2 {
+                private struct NoPublicCodable2\(sutSuffix) {
                     let brand: Brand
                 }
 
                 @Codable
-                internal struct NoPublicCodable3 {
+                internal struct NoPublicCodable3\(sutSuffix) {
                     let brand: Brand
                 }
 
                 @Codable
-                public struct WithPublicCodable {
+                public struct WithPublicCodable\(sutSuffix) {
                 }
                 """
             } expansion: {
                 """
-                struct NoPublicCodable1 {
+                struct NoPublicCodable1__testing__ {
                     let brand: Brand
                 }
-                private struct NoPublicCodable2 {
+                private struct NoPublicCodable2__testing__ {
                     let brand: Brand
                 }
-                internal struct NoPublicCodable3 {
+                internal struct NoPublicCodable3__testing__ {
                     let brand: Brand
                 }
-                public struct WithPublicCodable {
+                public struct WithPublicCodable__testing__ {
                 }
 
-                extension NoPublicCodable1: Decodable, Encodable {
+                extension NoPublicCodable1__testing__: Decodable, Encodable {
                     enum CodingKeys: String, CodingKey {
                         case brand
                     }
@@ -280,7 +305,7 @@ final class CodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension NoPublicCodable2: Decodable, Encodable {
+                extension NoPublicCodable2__testing__: Decodable, Encodable {
                     enum CodingKeys: String, CodingKey {
                         case brand
                     }
@@ -294,7 +319,7 @@ final class CodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension NoPublicCodable3: Decodable, Encodable {
+                extension NoPublicCodable3__testing__: Decodable, Encodable {
                     enum CodingKeys: String, CodingKey {
                         case brand
                     }
@@ -308,7 +333,7 @@ final class CodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension WithPublicCodable: Decodable, Encodable {
+                extension WithPublicCodable__testing__: Decodable, Encodable {
                     public init(from decoder: Decoder) throws {
                     }
                     public func encode(to encoder: Encoder) throws {

--- a/Tests/MacroCodableKitTests/Codable/DecodableMacroTests.swift
+++ b/Tests/MacroCodableKitTests/Codable/DecodableMacroTests.swift
@@ -26,33 +26,33 @@ final class DecodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @Decodable
-                enum NoApplicable {}
+                enum NoApplicable\(sutSuffix) {}
                 """
             } diagnostics: {
                 """
                 @Decodable
                 ╰─ 🛑 '@Decodable' macro can only be applied to a struct
-                enum NoApplicable {}
+                enum NoApplicable__testing__ {}
                 """
             }
 
             assertMacro {
                 """
                 @Decodable
-                class NoApplicable {}
+                class NoApplicable\(sutSuffix) {}
                 """
             } diagnostics: {
                 """
                 @Decodable
                 ╰─ 🛑 '@Decodable' macro can only be applied to a struct
-                class NoApplicable {}
+                class NoApplicable__testing__ {}
                 """
             }
 
             assertMacro {
                 """
                 @Decodable
-                struct Example {
+                struct Example\(sutSuffix) {
                     let brand: Brand?
                     let company: Company
 
@@ -71,7 +71,7 @@ final class DecodableMacroTests: XCTestCase {
                 """
             } expansion: {
                 """
-                struct Example {
+                struct Example__testing__ {
                     let brand: Brand?
                     let company: Company
                     let omittedCompany: Company
@@ -82,7 +82,7 @@ final class DecodableMacroTests: XCTestCase {
                     let available: Bool
                 }
 
-                extension Example: Decodable {
+                extension Example__testing__: Decodable {
                     enum CodingKeys: String, CodingKey {
                         case brand
                         case company
@@ -103,41 +103,65 @@ final class DecodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @Decodable
-                struct NoCodableExample {
+                struct NoCodableExample\(sutSuffix) {
                     let brand: Brand
                 }
 
                 @Decodable
-                struct OnlyEncodableExample: Encodable {
+                struct OnlyEncodableExample\(sutSuffix): Encodable {
                     let brand: Brand
                 }
 
                 @Decodable
-                struct OnlyDecodableExample: Decodable {
+                struct OnlyDecodableExample\(sutSuffix): Decodable {
                     let brand: Brand
                 }
 
                 @Decodable
-                struct CodableExample: Codable {
+                struct CodableExample\(sutSuffix): Codable {
+                    let brand: Brand
+                }
+                """
+            } diagnostics: {
+                """
+                @Decodable
+                struct NoCodableExample__testing__ {
+                    let brand: Brand
+                }
+
+                @Decodable
+                struct OnlyEncodableExample__testing__: Encodable {
+                    let brand: Brand
+                }
+
+                @Decodable
+                ╰─ ⚠️ '@Decodable' macro has not effect since 'OnlyDecodableExample__testing__' already conformes to ["Decodable"]. Consider removing '@Decodable'
+                struct OnlyDecodableExample__testing__: Decodable {
+                    let brand: Brand
+                }
+
+                @Decodable
+                ╰─ ⚠️ '@Decodable' macro has not effect since 'CodableExample__testing__' already conformes to ["Decodable"]. Consider removing '@Decodable'
+                struct CodableExample__testing__: Codable {
                     let brand: Brand
                 }
                 """
             } expansion: {
                 """
-                struct NoCodableExample {
+                struct NoCodableExample__testing__ {
                     let brand: Brand
                 }
-                struct OnlyEncodableExample: Encodable {
+                struct OnlyEncodableExample__testing__: Encodable {
                     let brand: Brand
                 }
-                struct OnlyDecodableExample: Decodable {
+                struct OnlyDecodableExample__testing__: Decodable {
                     let brand: Brand
                 }
-                struct CodableExample: Codable {
+                struct CodableExample__testing__: Codable {
                     let brand: Brand
                 }
 
-                extension NoCodableExample: Decodable {
+                extension NoCodableExample__testing__: Decodable {
                     enum CodingKeys: String, CodingKey {
                         case brand
                     }
@@ -147,7 +171,7 @@ final class DecodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension OnlyEncodableExample: Decodable {
+                extension OnlyEncodableExample__testing__: Decodable {
                     enum CodingKeys: String, CodingKey {
                         case brand
                     }
@@ -162,42 +186,42 @@ final class DecodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @Decodable
-                struct Empty1 {
+                struct Empty1\(sutSuffix) {
                     @OmitCoding
                     let brand: Brand
                 }
 
                 @Decodable
-                struct Empty2 {
+                struct Empty2\(sutSuffix) {
                 }
 
                 @Decodable
-                struct Empty3 {
+                struct Empty3\(sutSuffix) {
                     var string: String { "" }
                 }
                 """
             } expansion: {
                 """
-                struct Empty1 {
+                struct Empty1__testing__ {
                     let brand: Brand
                 }
-                struct Empty2 {
+                struct Empty2__testing__ {
                 }
-                struct Empty3 {
+                struct Empty3__testing__ {
                     var string: String { "" }
                 }
 
-                extension Empty1: Decodable {
+                extension Empty1__testing__: Decodable {
                     init(from decoder: Decoder) throws {
                     }
                 }
 
-                extension Empty2: Decodable {
+                extension Empty2__testing__: Decodable {
                     init(from decoder: Decoder) throws {
                     }
                 }
 
-                extension Empty3: Decodable {
+                extension Empty3__testing__: Decodable {
                     init(from decoder: Decoder) throws {
                     }
                 }
@@ -207,39 +231,39 @@ final class DecodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @Decodable
-                struct NoAccessorSpecifier {
+                struct NoAccessorSpecifier\(sutSuffix) {
                     let brand: Brand
                 }
 
                 @Decodable
-                private struct NoPublicCodable2 {
+                private struct NoPublicCodable2\(sutSuffix) {
                     let brand: Brand
                 }
 
                 @Decodable
-                internal struct NoPublicCodable3 {
+                internal struct NoPublicCodable3\(sutSuffix) {
                     let brand: Brand
                 }
 
                 @Decodable
-                public struct WithPublicCodable {
+                public struct WithPublicCodable\(sutSuffix) {
                 }
                 """
             } expansion: {
                 """
-                struct NoAccessorSpecifier {
+                struct NoAccessorSpecifier__testing__ {
                     let brand: Brand
                 }
-                private struct NoPublicCodable2 {
+                private struct NoPublicCodable2__testing__ {
                     let brand: Brand
                 }
-                internal struct NoPublicCodable3 {
+                internal struct NoPublicCodable3__testing__ {
                     let brand: Brand
                 }
-                public struct WithPublicCodable {
+                public struct WithPublicCodable__testing__ {
                 }
 
-                extension NoAccessorSpecifier: Decodable {
+                extension NoAccessorSpecifier__testing__: Decodable {
                     enum CodingKeys: String, CodingKey {
                         case brand
                     }
@@ -249,7 +273,7 @@ final class DecodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension NoPublicCodable2: Decodable {
+                extension NoPublicCodable2__testing__: Decodable {
                     enum CodingKeys: String, CodingKey {
                         case brand
                     }
@@ -259,7 +283,7 @@ final class DecodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension NoPublicCodable3: Decodable {
+                extension NoPublicCodable3__testing__: Decodable {
                     enum CodingKeys: String, CodingKey {
                         case brand
                     }
@@ -269,7 +293,7 @@ final class DecodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension WithPublicCodable: Decodable {
+                extension WithPublicCodable__testing__: Decodable {
                     public init(from decoder: Decoder) throws {
                     }
                 }

--- a/Tests/MacroCodableKitTests/Codable/EncodableMacroTests.swift
+++ b/Tests/MacroCodableKitTests/Codable/EncodableMacroTests.swift
@@ -26,33 +26,33 @@ final class EncodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @Encodable
-                enum NoApplicable {}
+                enum NoApplicable\(sutSuffix) {}
                 """
             } diagnostics: {
                 """
                 @Encodable
                 ╰─ 🛑 '@Encodable' macro can only be applied to a struct
-                enum NoApplicable {}
+                enum NoApplicable__testing__ {}
                 """
             }
 
             assertMacro {
                 """
                 @Encodable
-                class NoApplicable {}
+                class NoApplicable\(sutSuffix) {}
                 """
             } diagnostics: {
                 """
                 @Encodable
                 ╰─ 🛑 '@Encodable' macro can only be applied to a struct
-                class NoApplicable {}
+                class NoApplicable__testing__ {}
                 """
             }
 
             assertMacro {
                 """
                 @Encodable
-                struct Example {
+                struct Example\(sutSuffix) {
                     let brand: Brand?
                     let company: Company
 
@@ -71,7 +71,7 @@ final class EncodableMacroTests: XCTestCase {
                 """
             } expansion: {
                 """
-                struct Example {
+                struct Example__testing__ {
                     let brand: Brand?
                     let company: Company
                     let omittedCompany: Company
@@ -82,7 +82,7 @@ final class EncodableMacroTests: XCTestCase {
                     let available: Bool
                 }
 
-                extension Example: Encodable {
+                extension Example__testing__: Encodable {
                     enum CodingKeys: String, CodingKey {
                         case brand
                         case company
@@ -103,41 +103,65 @@ final class EncodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @Encodable
-                struct NoCodableExample {
+                struct NoCodableExample\(sutSuffix) {
                     let brand: Brand
                 }
 
                 @Encodable
-                struct OnlyEncodableExample: Encodable {
+                struct OnlyEncodableExample\(sutSuffix): Encodable {
                     let brand: Brand
                 }
 
                 @Encodable
-                struct OnlyDecodableExample: Decodable {
+                struct OnlyDecodableExample\(sutSuffix): Decodable {
                     let brand: Brand
                 }
 
                 @Encodable
-                struct CodableExample: Codable {
+                struct CodableExample\(sutSuffix): Codable {
+                    let brand: Brand
+                }
+                """
+            } diagnostics: {
+                """
+                @Encodable
+                struct NoCodableExample__testing__ {
+                    let brand: Brand
+                }
+
+                @Encodable
+                ╰─ ⚠️ '@Encodable' macro has not effect since 'OnlyEncodableExample__testing__' already conformes to ["Encodable"]. Consider removing '@Encodable'
+                struct OnlyEncodableExample__testing__: Encodable {
+                    let brand: Brand
+                }
+
+                @Encodable
+                struct OnlyDecodableExample__testing__: Decodable {
+                    let brand: Brand
+                }
+
+                @Encodable
+                ╰─ ⚠️ '@Encodable' macro has not effect since 'CodableExample__testing__' already conformes to ["Encodable"]. Consider removing '@Encodable'
+                struct CodableExample__testing__: Codable {
                     let brand: Brand
                 }
                 """
             } expansion: {
                 """
-                struct NoCodableExample {
+                struct NoCodableExample__testing__ {
                     let brand: Brand
                 }
-                struct OnlyEncodableExample: Encodable {
+                struct OnlyEncodableExample__testing__: Encodable {
                     let brand: Brand
                 }
-                struct OnlyDecodableExample: Decodable {
+                struct OnlyDecodableExample__testing__: Decodable {
                     let brand: Brand
                 }
-                struct CodableExample: Codable {
+                struct CodableExample__testing__: Codable {
                     let brand: Brand
                 }
 
-                extension NoCodableExample: Encodable {
+                extension NoCodableExample__testing__: Encodable {
                     enum CodingKeys: String, CodingKey {
                         case brand
                     }
@@ -147,7 +171,7 @@ final class EncodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension OnlyDecodableExample: Encodable {
+                extension OnlyDecodableExample__testing__: Encodable {
                     enum CodingKeys: String, CodingKey {
                         case brand
                     }
@@ -162,42 +186,42 @@ final class EncodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @Encodable
-                struct Empty1 {
+                struct Empty1\(sutSuffix) {
                     @OmitCoding
                     let brand: Brand
                 }
 
                 @Encodable
-                struct Empty2 {
+                struct Empty2\(sutSuffix) {
                 }
 
                 @Encodable
-                struct Empty3 {
+                struct Empty3\(sutSuffix) {
                     var string: String { "" }
                 }
                 """
             } expansion: {
                 """
-                struct Empty1 {
+                struct Empty1__testing__ {
                     let brand: Brand
                 }
-                struct Empty2 {
+                struct Empty2__testing__ {
                 }
-                struct Empty3 {
+                struct Empty3__testing__ {
                     var string: String { "" }
                 }
 
-                extension Empty1: Encodable {
+                extension Empty1__testing__: Encodable {
                     func encode(to encoder: Encoder) throws {
                     }
                 }
 
-                extension Empty2: Encodable {
+                extension Empty2__testing__: Encodable {
                     func encode(to encoder: Encoder) throws {
                     }
                 }
 
-                extension Empty3: Encodable {
+                extension Empty3__testing__: Encodable {
                     func encode(to encoder: Encoder) throws {
                     }
                 }
@@ -207,39 +231,39 @@ final class EncodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @Encodable
-                struct NoPublicCodable1 {
+                struct NoPublicCodable1\(sutSuffix) {
                     let brand: Brand
                 }
 
                 @Encodable
-                private struct NoPublicCodable2 {
+                private struct NoPublicCodable2\(sutSuffix) {
                     let brand: Brand
                 }
 
                 @Encodable
-                internal struct NoPublicCodable3 {
+                internal struct NoPublicCodable3\(sutSuffix) {
                     let brand: Brand
                 }
 
                 @Encodable
-                public struct WithPublicCodable {
+                public struct WithPublicCodable\(sutSuffix) {
                 }
                 """
             } expansion: {
                 """
-                struct NoPublicCodable1 {
+                struct NoPublicCodable1__testing__ {
                     let brand: Brand
                 }
-                private struct NoPublicCodable2 {
+                private struct NoPublicCodable2__testing__ {
                     let brand: Brand
                 }
-                internal struct NoPublicCodable3 {
+                internal struct NoPublicCodable3__testing__ {
                     let brand: Brand
                 }
-                public struct WithPublicCodable {
+                public struct WithPublicCodable__testing__ {
                 }
 
-                extension NoPublicCodable1: Encodable {
+                extension NoPublicCodable1__testing__: Encodable {
                     enum CodingKeys: String, CodingKey {
                         case brand
                     }
@@ -249,7 +273,7 @@ final class EncodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension NoPublicCodable2: Encodable {
+                extension NoPublicCodable2__testing__: Encodable {
                     enum CodingKeys: String, CodingKey {
                         case brand
                     }
@@ -259,7 +283,7 @@ final class EncodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension NoPublicCodable3: Encodable {
+                extension NoPublicCodable3__testing__: Encodable {
                     enum CodingKeys: String, CodingKey {
                         case brand
                     }
@@ -269,7 +293,7 @@ final class EncodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension WithPublicCodable: Encodable {
+                extension WithPublicCodable__testing__: Encodable {
                     public func encode(to encoder: Encoder) throws {
                     }
                 }

--- a/Tests/MacroCodableKitTests/Helpers/Misc.swift
+++ b/Tests/MacroCodableKitTests/Helpers/Misc.swift
@@ -1,0 +1,8 @@
+//
+//  Misc.swift
+//
+//
+//  Created by Mikhail Maslo on 08.10.23.
+//
+
+let sutSuffix = "__testing__"

--- a/Tests/MacroCodableKitTests/OneOfCodable/OneOfCodableMacroTests.swift
+++ b/Tests/MacroCodableKitTests/OneOfCodable/OneOfCodableMacroTests.swift
@@ -24,33 +24,33 @@ final class OneOfCodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @OneOfCodable
-                struct NoApplicable {}
+                struct NoApplicable\(sutSuffix) {}
                 """
             } diagnostics: {
                 """
                 @OneOfCodable
                 ╰─ 🛑 '@OneOfCodable' macro can only be applied to a enum
-                struct NoApplicable {}
+                struct NoApplicable__testing__ {}
                 """
             }
 
             assertMacro {
                 """
                 @OneOfCodable
-                class NoApplicable {}
+                class NoApplicable\(sutSuffix) {}
                 """
             } diagnostics: {
                 """
                 @OneOfCodable
                 ╰─ 🛑 '@OneOfCodable' macro can only be applied to a enum
-                class NoApplicable {}
+                class NoApplicable__testing__ {}
                 """
             }
 
             assertMacro {
                 """
                 @OneOfCodable
-                enum Applicable {
+                enum Applicable\(sutSuffix) {
                     case int(Int)
                     case optionalInt(Int?)
                     case withLabel(label: Int)
@@ -61,7 +61,7 @@ final class OneOfCodableMacroTests: XCTestCase {
                 """
             } expansion: {
                 """
-                enum Applicable {
+                enum Applicable__testing__ {
                     case int(Int)
                     case optionalInt(Int?)
                     case withLabel(label: Int)
@@ -70,7 +70,7 @@ final class OneOfCodableMacroTests: XCTestCase {
                     case optionalWithUnderscoredLabel(_ label: Int?)
                 }
 
-                extension Applicable: Decodable, Encodable {
+                extension Applicable__testing__: Decodable, Encodable {
                     enum CodingKeys: String, CodingKey {
                         case int
                         case optionalInt
@@ -125,49 +125,105 @@ final class OneOfCodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @OneOfCodable
-                enum NoCodableExample: Encodable {
+                enum NoCodableExample\(sutSuffix) {
                     case int(Int)
                 }
 
                 @OneOfCodable
-                enum OnlyEncodableExample: Encodable {
+                enum OnlyEncodableExample\(sutSuffix): Encodable {
                     case int(Int)
                 }
 
                 @OneOfCodable
-                enum OnlyDecodableExample: Decodable {
+                enum OnlyDecodableExample\(sutSuffix): Decodable {
                     case int(Int)
                 }
 
                 @OneOfCodable
-                enum EncodableAndCodableExample: Encodable, Decodable {
+                enum EncodableAndCodableExample\(sutSuffix): Encodable, Decodable {
                     case int(Int)
                 }
 
                 @OneOfCodable
-                enum CodableExample: Codable {
+                enum CodableExample\(sutSuffix): Codable {
                     case int(Int)
                 }
                 """
-            } expansion: {
+            } diagnostics: {
                 """
-                enum NoCodableExample: Encodable {
-                    case int(Int)
-                }
-                enum OnlyEncodableExample: Encodable {
-                    case int(Int)
-                }
-                enum OnlyDecodableExample: Decodable {
-                    case int(Int)
-                }
-                enum EncodableAndCodableExample: Encodable, Decodable {
-                    case int(Int)
-                }
-                enum CodableExample: Codable {
+                @OneOfCodable
+                enum NoCodableExample__testing__ {
                     case int(Int)
                 }
 
-                extension NoCodableExample: Decodable {
+                @OneOfCodable
+                ╰─ ⚠️ '@OneOfCodable' macro won't generate 'Encodable' conformance since 'OnlyEncodableExample__testing__' already conformes to it. Consider using '@OneOfDecodable' instead
+                enum OnlyEncodableExample__testing__: Encodable {
+                    case int(Int)
+                }
+
+                @OneOfCodable
+                ╰─ ⚠️ '@OneOfCodable' macro won't generate 'Decodable' conformance since 'OnlyDecodableExample__testing__' already conformes to it. Consider using '@OneOfEncodable' instead
+                enum OnlyDecodableExample__testing__: Decodable {
+                    case int(Int)
+                }
+
+                @OneOfCodable
+                ╰─ ⚠️ '@OneOfCodable' macro has not effect since 'EncodableAndCodableExample__testing__' already conformes to ["Decodable", "Encodable"]. Consider removing '@OneOfCodable'
+                enum EncodableAndCodableExample__testing__: Encodable, Decodable {
+                    case int(Int)
+                }
+
+                @OneOfCodable
+                ╰─ ⚠️ '@OneOfCodable' macro has not effect since 'CodableExample__testing__' already conformes to ["Decodable", "Encodable"]. Consider removing '@OneOfCodable'
+                enum CodableExample__testing__: Codable {
+                    case int(Int)
+                }
+                """
+            }expansion: {
+                """
+                enum NoCodableExample__testing__ {
+                    case int(Int)
+                }
+                enum OnlyEncodableExample__testing__: Encodable {
+                    case int(Int)
+                }
+                enum OnlyDecodableExample__testing__: Decodable {
+                    case int(Int)
+                }
+                enum EncodableAndCodableExample__testing__: Encodable, Decodable {
+                    case int(Int)
+                }
+                enum CodableExample__testing__: Codable {
+                    case int(Int)
+                }
+
+                extension NoCodableExample__testing__: Decodable, Encodable {
+                    enum CodingKeys: String, CodingKey {
+                        case int
+                    }
+                    init(from decoder: Decoder) throws {
+                        let container = try decoder.container(keyedBy: CodingKeys.self)
+                        guard let key = container.allKeys.first else {
+                            throw DecodingError.dataCorrupted(
+                                .init(codingPath: decoder.codingPath, debugDescription: "Unknown enum case.")
+                            )
+                        }
+                        switch key {
+                        case .int:
+                            self = .int(try container.decode(Int.self, forKey: key))
+                        }
+                    }
+                    func encode(to encoder: Encoder) throws {
+                        var container = encoder.container(keyedBy: CodingKeys.self)
+                        switch self {
+                        case .int(let payload):
+                            try container.encode(payload, forKey: .int)
+                        }
+                    }
+                }
+
+                extension OnlyEncodableExample__testing__: Decodable {
                     enum CodingKeys: String, CodingKey {
                         case int
                     }
@@ -185,25 +241,7 @@ final class OneOfCodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension OnlyEncodableExample: Decodable {
-                    enum CodingKeys: String, CodingKey {
-                        case int
-                    }
-                    init(from decoder: Decoder) throws {
-                        let container = try decoder.container(keyedBy: CodingKeys.self)
-                        guard let key = container.allKeys.first else {
-                            throw DecodingError.dataCorrupted(
-                                .init(codingPath: decoder.codingPath, debugDescription: "Unknown enum case.")
-                            )
-                        }
-                        switch key {
-                        case .int:
-                            self = .int(try container.decode(Int.self, forKey: key))
-                        }
-                    }
-                }
-
-                extension OnlyDecodableExample: Encodable {
+                extension OnlyDecodableExample__testing__: Encodable {
                     enum CodingKeys: String, CodingKey {
                         case int
                     }
@@ -221,13 +259,13 @@ final class OneOfCodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @OneOfCodable
-                enum Empty {}
+                enum Empty\(sutSuffix) {}
                 """
             } expansion: {
                 """
-                enum Empty {}
+                enum Empty__testing__ {}
 
-                extension Empty: Decodable, Encodable {
+                extension Empty__testing__: Decodable, Encodable {
                     init(from decoder: Decoder) throws {
                     }
                     func encode(to encoder: Encoder) throws {
@@ -239,41 +277,41 @@ final class OneOfCodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @OneOfCodable
-                enum NoPublicCodable1 {
+                enum NoPublicCodable1\(sutSuffix) {
                     case int(Int)
                 }
 
                 @OneOfCodable
-                private enum NoPublicCodable2 {
+                private enum NoPublicCodable2\(sutSuffix) {
                     case int(Int)
                 }
 
                 @OneOfCodable
-                internal enum NoPublicCodable3 {
+                internal enum NoPublicCodable3\(sutSuffix) {
                     case int(Int)
                 }
 
                 @OneOfCodable
-                internal enum PublicCodable1 {
+                internal enum PublicCodable1\(sutSuffix) {
                     case int(Int)
                 }
                 """
             } expansion: {
                 """
-                enum NoPublicCodable1 {
+                enum NoPublicCodable1__testing__ {
                     case int(Int)
                 }
-                private enum NoPublicCodable2 {
+                private enum NoPublicCodable2__testing__ {
                     case int(Int)
                 }
-                internal enum NoPublicCodable3 {
+                internal enum NoPublicCodable3__testing__ {
                     case int(Int)
                 }
-                internal enum PublicCodable1 {
+                internal enum PublicCodable1__testing__ {
                     case int(Int)
                 }
 
-                extension NoPublicCodable1: Decodable, Encodable {
+                extension NoPublicCodable1__testing__: Decodable, Encodable {
                     enum CodingKeys: String, CodingKey {
                         case int
                     }
@@ -298,7 +336,7 @@ final class OneOfCodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension NoPublicCodable2: Decodable, Encodable {
+                extension NoPublicCodable2__testing__: Decodable, Encodable {
                     enum CodingKeys: String, CodingKey {
                         case int
                     }
@@ -323,7 +361,7 @@ final class OneOfCodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension NoPublicCodable3: Decodable, Encodable {
+                extension NoPublicCodable3__testing__: Decodable, Encodable {
                     enum CodingKeys: String, CodingKey {
                         case int
                     }
@@ -348,7 +386,7 @@ final class OneOfCodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension PublicCodable1: Decodable, Encodable {
+                extension PublicCodable1__testing__: Decodable, Encodable {
                     enum CodingKeys: String, CodingKey {
                         case int
                     }
@@ -387,14 +425,14 @@ final class OneOfCodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @OneOfCodable
-                enum Example {
+                enum Example\(sutSuffix) {
                     case a
                 }
                 """
             } diagnostics: {
                 """
                 @OneOfCodable
-                enum Example {
+                enum Example__testing__ {
                     case a
                          ┬
                          ╰─ 🛑 '@OneOfCodable' macro requires each case to have one associated value
@@ -405,14 +443,14 @@ final class OneOfCodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @OneOfCodable
-                enum Example {
+                enum Example\(sutSuffix) {
                     case a(Int, Int)
                 }
                 """
             } diagnostics: {
                 """
                 @OneOfCodable
-                enum Example {
+                enum Example__testing__ {
                     case a(Int, Int)
                          ┬──────────
                          ╰─ 🛑 '@OneOfCodable' macro requires each case to have one associated value

--- a/Tests/MacroCodableKitTests/OneOfCodable/OneOfDecodableMacroTests.swift
+++ b/Tests/MacroCodableKitTests/OneOfCodable/OneOfDecodableMacroTests.swift
@@ -24,45 +24,45 @@ final class OneOfDecodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @OneOfDecodable
-                struct NoApplicable {}
+                struct NoApplicable\(sutSuffix) {}
                 """
             } diagnostics: {
                 """
                 @OneOfDecodable
                 ╰─ 🛑 '@OneOfDecodable' macro can only be applied to a enum
-                struct NoApplicable {}
+                struct NoApplicable__testing__ {}
                 """
             }
 
             assertMacro {
                 """
                 @OneOfDecodable
-                class NoApplicable {}
+                class NoApplicable\(sutSuffix) {}
                 """
             } diagnostics: {
                 """
                 @OneOfDecodable
                 ╰─ 🛑 '@OneOfDecodable' macro can only be applied to a enum
-                class NoApplicable {}
+                class NoApplicable__testing__ {}
                 """
             }
 
             assertMacro {
                 """
                 @OneOfDecodable
-                enum Applicable {
+                enum Applicable\(sutSuffix) {
                     case int(Int)
                     case optionalInt(Int?)
                 }
                 """
             } expansion: {
                 """
-                enum Applicable {
+                enum Applicable__testing__ {
                     case int(Int)
                     case optionalInt(Int?)
                 }
 
-                extension Applicable: Decodable {
+                extension Applicable__testing__: Decodable {
                     enum CodingKeys: String, CodingKey {
                         case int
                         case optionalInt
@@ -88,49 +88,79 @@ final class OneOfDecodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @OneOfDecodable
-                enum NoCodableExample: Encodable {
+                enum NoCodableExample\(sutSuffix) {
                     case int(Int)
                 }
 
                 @OneOfDecodable
-                enum OnlyEncodableExample: Encodable {
+                enum OnlyEncodableExample\(sutSuffix): Encodable {
                     case int(Int)
                 }
 
                 @OneOfDecodable
-                enum OnlyDecodableExample: Decodable {
+                enum OnlyDecodableExample\(sutSuffix): Decodable {
                     case int(Int)
                 }
 
                 @OneOfDecodable
-                enum EncodableAndCodableExample: Encodable, Decodable {
+                enum EncodableAndCodableExample\(sutSuffix): Encodable, Decodable {
                     case int(Int)
                 }
 
                 @OneOfDecodable
-                enum CodableExample: Codable {
+                enum CodableExample\(sutSuffix): Codable {
                     case int(Int)
                 }
                 """
-            } expansion: {
+            } diagnostics: {
                 """
-                enum NoCodableExample: Encodable {
-                    case int(Int)
-                }
-                enum OnlyEncodableExample: Encodable {
-                    case int(Int)
-                }
-                enum OnlyDecodableExample: Decodable {
-                    case int(Int)
-                }
-                enum EncodableAndCodableExample: Encodable, Decodable {
-                    case int(Int)
-                }
-                enum CodableExample: Codable {
+                @OneOfDecodable
+                enum NoCodableExample__testing__ {
                     case int(Int)
                 }
 
-                extension NoCodableExample: Decodable {
+                @OneOfDecodable
+                enum OnlyEncodableExample__testing__: Encodable {
+                    case int(Int)
+                }
+
+                @OneOfDecodable
+                ╰─ ⚠️ '@OneOfDecodable' macro has not effect since 'OnlyDecodableExample__testing__' already conformes to ["Decodable"]. Consider removing '@OneOfDecodable'
+                enum OnlyDecodableExample__testing__: Decodable {
+                    case int(Int)
+                }
+
+                @OneOfDecodable
+                ╰─ ⚠️ '@OneOfDecodable' macro has not effect since 'EncodableAndCodableExample__testing__' already conformes to ["Decodable"]. Consider removing '@OneOfDecodable'
+                enum EncodableAndCodableExample__testing__: Encodable, Decodable {
+                    case int(Int)
+                }
+
+                @OneOfDecodable
+                ╰─ ⚠️ '@OneOfDecodable' macro has not effect since 'CodableExample__testing__' already conformes to ["Decodable"]. Consider removing '@OneOfDecodable'
+                enum CodableExample__testing__: Codable {
+                    case int(Int)
+                }
+                """
+            }expansion: {
+                """
+                enum NoCodableExample__testing__ {
+                    case int(Int)
+                }
+                enum OnlyEncodableExample__testing__: Encodable {
+                    case int(Int)
+                }
+                enum OnlyDecodableExample__testing__: Decodable {
+                    case int(Int)
+                }
+                enum EncodableAndCodableExample__testing__: Encodable, Decodable {
+                    case int(Int)
+                }
+                enum CodableExample__testing__: Codable {
+                    case int(Int)
+                }
+
+                extension NoCodableExample__testing__: Decodable {
                     enum CodingKeys: String, CodingKey {
                         case int
                     }
@@ -148,7 +178,7 @@ final class OneOfDecodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension OnlyEncodableExample: Decodable {
+                extension OnlyEncodableExample__testing__: Decodable {
                     enum CodingKeys: String, CodingKey {
                         case int
                     }
@@ -171,13 +201,13 @@ final class OneOfDecodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @OneOfDecodable
-                enum Empty {}
+                enum Empty\(sutSuffix) {}
                 """
             } expansion: {
                 """
-                enum Empty {}
+                enum Empty__testing__ {}
 
-                extension Empty: Decodable {
+                extension Empty__testing__: Decodable {
                     init(from decoder: Decoder) throws {
                     }
                 }
@@ -187,41 +217,41 @@ final class OneOfDecodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @OneOfDecodable
-                enum NoPublicCodable1 {
+                enum NoPublicCodable1\(sutSuffix) {
                     case int(Int)
                 }
 
                 @OneOfDecodable
-                private enum NoPublicCodable2 {
+                private enum NoPublicCodable2\(sutSuffix) {
                     case int(Int)
                 }
 
                 @OneOfDecodable
-                internal enum NoPublicCodable3 {
+                internal enum NoPublicCodable3\(sutSuffix) {
                     case int(Int)
                 }
 
                 @OneOfDecodable
-                internal enum PublicCodable1 {
+                internal enum PublicCodable1\(sutSuffix) {
                     case int(Int)
                 }
                 """
             } expansion: {
                 """
-                enum NoPublicCodable1 {
+                enum NoPublicCodable1__testing__ {
                     case int(Int)
                 }
-                private enum NoPublicCodable2 {
+                private enum NoPublicCodable2__testing__ {
                     case int(Int)
                 }
-                internal enum NoPublicCodable3 {
+                internal enum NoPublicCodable3__testing__ {
                     case int(Int)
                 }
-                internal enum PublicCodable1 {
+                internal enum PublicCodable1__testing__ {
                     case int(Int)
                 }
 
-                extension NoPublicCodable1: Decodable {
+                extension NoPublicCodable1__testing__: Decodable {
                     enum CodingKeys: String, CodingKey {
                         case int
                     }
@@ -239,7 +269,7 @@ final class OneOfDecodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension NoPublicCodable2: Decodable {
+                extension NoPublicCodable2__testing__: Decodable {
                     enum CodingKeys: String, CodingKey {
                         case int
                     }
@@ -257,7 +287,7 @@ final class OneOfDecodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension NoPublicCodable3: Decodable {
+                extension NoPublicCodable3__testing__: Decodable {
                     enum CodingKeys: String, CodingKey {
                         case int
                     }
@@ -275,7 +305,7 @@ final class OneOfDecodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension PublicCodable1: Decodable {
+                extension PublicCodable1__testing__: Decodable {
                     enum CodingKeys: String, CodingKey {
                         case int
                     }

--- a/Tests/MacroCodableKitTests/OneOfCodable/OneOfEncodableMacroTests.swift
+++ b/Tests/MacroCodableKitTests/OneOfCodable/OneOfEncodableMacroTests.swift
@@ -24,45 +24,49 @@ final class OneOfEncodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @OneOfEncodable
-                struct NoApplicable {}
+                struct NoApplicable\(sutSuffix) {}
                 """
             } diagnostics: {
                 """
                 @OneOfEncodable
                 ╰─ 🛑 '@OneOfEncodable' macro can only be applied to a enum
-                struct NoApplicable {}
+                struct NoApplicable__testing__ {}
                 """
             }
 
             assertMacro {
                 """
                 @OneOfEncodable
-                class NoApplicable {}
+                class NoApplicable\(sutSuffix) {}
                 """
             } diagnostics: {
                 """
                 @OneOfEncodable
                 ╰─ 🛑 '@OneOfEncodable' macro can only be applied to a enum
-                class NoApplicable {}
+                class NoApplicable__testing__ {}
                 """
             }
 
             assertMacro {
                 """
                 @OneOfEncodable
-                enum Applicable {
+                enum Applicable\(sutSuffix) {
                     case int(Int)
                     case optionalInt(Int?)
                 }
                 """
-            } expansion: {
+            } diagnostics: {
                 """
-                enum Applicable {
+
+                """
+            }expansion: {
+                """
+                enum Applicable__testing__ {
                     case int(Int)
                     case optionalInt(Int?)
                 }
 
-                extension Applicable: Encodable {
+                extension Applicable__testing__: Encodable {
                     enum CodingKeys: String, CodingKey {
                         case int
                         case optionalInt
@@ -83,49 +87,92 @@ final class OneOfEncodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @OneOfEncodable
-                enum NoCodableExample: Encodable {
+                enum NoCodableExample\(sutSuffix) {
                     case int(Int)
                 }
 
                 @OneOfEncodable
-                enum OnlyEncodableExample: Encodable {
+                enum OnlyEncodableExample\(sutSuffix): Encodable {
                     case int(Int)
                 }
 
                 @OneOfEncodable
-                enum OnlyDecodableExample: Decodable {
+                enum OnlyDecodableExample\(sutSuffix): Decodable {
                     case int(Int)
                 }
 
                 @OneOfEncodable
-                enum EncodableAndCodableExample: Encodable, Decodable {
+                enum EncodableAndCodableExample\(sutSuffix): Encodable, Decodable {
                     case int(Int)
                 }
 
                 @OneOfEncodable
-                enum CodableExample: Codable {
+                enum CodableExample\(sutSuffix): Codable {
                     case int(Int)
                 }
                 """
-            } expansion: {
+            } diagnostics: {
                 """
-                enum NoCodableExample: Encodable {
-                    case int(Int)
-                }
-                enum OnlyEncodableExample: Encodable {
-                    case int(Int)
-                }
-                enum OnlyDecodableExample: Decodable {
-                    case int(Int)
-                }
-                enum EncodableAndCodableExample: Encodable, Decodable {
-                    case int(Int)
-                }
-                enum CodableExample: Codable {
+                @OneOfEncodable
+                enum NoCodableExample__testing__ {
                     case int(Int)
                 }
 
-                extension OnlyDecodableExample: Encodable {
+                @OneOfEncodable
+                ╰─ ⚠️ '@OneOfEncodable' macro has not effect since 'OnlyEncodableExample__testing__' already conformes to ["Encodable"]. Consider removing '@OneOfEncodable'
+                enum OnlyEncodableExample__testing__: Encodable {
+                    case int(Int)
+                }
+
+                @OneOfEncodable
+                enum OnlyDecodableExample__testing__: Decodable {
+                    case int(Int)
+                }
+
+                @OneOfEncodable
+                ╰─ ⚠️ '@OneOfEncodable' macro has not effect since 'EncodableAndCodableExample__testing__' already conformes to ["Encodable"]. Consider removing '@OneOfEncodable'
+                enum EncodableAndCodableExample__testing__: Encodable, Decodable {
+                    case int(Int)
+                }
+
+                @OneOfEncodable
+                ╰─ ⚠️ '@OneOfEncodable' macro has not effect since 'CodableExample__testing__' already conformes to ["Encodable"]. Consider removing '@OneOfEncodable'
+                enum CodableExample__testing__: Codable {
+                    case int(Int)
+                }
+                """
+            }expansion: {
+                """
+                enum NoCodableExample__testing__ {
+                    case int(Int)
+                }
+                enum OnlyEncodableExample__testing__: Encodable {
+                    case int(Int)
+                }
+                enum OnlyDecodableExample__testing__: Decodable {
+                    case int(Int)
+                }
+                enum EncodableAndCodableExample__testing__: Encodable, Decodable {
+                    case int(Int)
+                }
+                enum CodableExample__testing__: Codable {
+                    case int(Int)
+                }
+
+                extension NoCodableExample__testing__: Encodable {
+                    enum CodingKeys: String, CodingKey {
+                        case int
+                    }
+                    func encode(to encoder: Encoder) throws {
+                        var container = encoder.container(keyedBy: CodingKeys.self)
+                        switch self {
+                        case .int(let payload):
+                            try container.encode(payload, forKey: .int)
+                        }
+                    }
+                }
+
+                extension OnlyDecodableExample__testing__: Encodable {
                     enum CodingKeys: String, CodingKey {
                         case int
                     }
@@ -143,13 +190,13 @@ final class OneOfEncodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @OneOfEncodable
-                enum Empty {}
+                enum Empty\(sutSuffix) {}
                 """
             } expansion: {
                 """
-                enum Empty {}
+                enum Empty__testing__ {}
 
-                extension Empty: Encodable {
+                extension Empty__testing__: Encodable {
                     func encode(to encoder: Encoder) throws {
                     }
                 }
@@ -159,41 +206,41 @@ final class OneOfEncodableMacroTests: XCTestCase {
             assertMacro {
                 """
                 @OneOfEncodable
-                enum NoPublicCodable1 {
+                enum NoPublicCodable1\(sutSuffix) {
                     case int(Int)
                 }
 
                 @OneOfEncodable
-                private enum NoPublicCodable2 {
+                private enum NoPublicCodable2\(sutSuffix) {
                     case int(Int)
                 }
 
                 @OneOfEncodable
-                internal enum NoPublicCodable3 {
+                internal enum NoPublicCodable3\(sutSuffix) {
                     case int(Int)
                 }
 
                 @OneOfEncodable
-                internal enum PublicCodable1 {
+                internal enum PublicCodable1\(sutSuffix) {
                     case int(Int)
                 }
                 """
             } expansion: {
                 """
-                enum NoPublicCodable1 {
+                enum NoPublicCodable1__testing__ {
                     case int(Int)
                 }
-                private enum NoPublicCodable2 {
+                private enum NoPublicCodable2__testing__ {
                     case int(Int)
                 }
-                internal enum NoPublicCodable3 {
+                internal enum NoPublicCodable3__testing__ {
                     case int(Int)
                 }
-                internal enum PublicCodable1 {
+                internal enum PublicCodable1__testing__ {
                     case int(Int)
                 }
 
-                extension NoPublicCodable1: Encodable {
+                extension NoPublicCodable1__testing__: Encodable {
                     enum CodingKeys: String, CodingKey {
                         case int
                     }
@@ -206,7 +253,7 @@ final class OneOfEncodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension NoPublicCodable2: Encodable {
+                extension NoPublicCodable2__testing__: Encodable {
                     enum CodingKeys: String, CodingKey {
                         case int
                     }
@@ -219,7 +266,7 @@ final class OneOfEncodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension NoPublicCodable3: Encodable {
+                extension NoPublicCodable3__testing__: Encodable {
                     enum CodingKeys: String, CodingKey {
                         case int
                     }
@@ -232,7 +279,7 @@ final class OneOfEncodableMacroTests: XCTestCase {
                     }
                 }
 
-                extension PublicCodable1: Encodable {
+                extension PublicCodable1__testing__: Encodable {
                     enum CodingKeys: String, CodingKey {
                         case int
                     }


### PR DESCRIPTION
At the same time, protocols provided by macro are always empty for tests, so we have to add `__testing__` tag to all sut

Before those changes macro couldn't detect such conformances
```swift
@Codable // Codable should conform only to Decodable, since Encodable is already provided by user
struct Example {
}

extension Example: Encodable { ... }
```

Using macro api which provides which conformances macro should generate resolve the case above