### PR TITLE
Remove Codable constraint on `ValueCodableStrategy.Value`

### DIFF
--- a/Sources/MacroCodableKit/Misc/CustomCoding/Types/CustomCodingDecoding+Types.swift
+++ b/Sources/MacroCodableKit/Misc/CustomCoding/Types/CustomCodingDecoding+Types.swift
@@ -747,8 +747,7 @@ public extension CustomCodingDecoding {
         strategy _: Strategy.Type
     ) throws -> T
         where Strategy: ValueCodableStrategy,
-        Strategy.Value == T,
-        T: Decodable
+        Strategy.Value == T
     {
         let valueDecoder = try container.superDecoder(forKey: key)
         return try Strategy.decode(from: valueDecoder)
@@ -762,7 +761,6 @@ public extension CustomCodingDecoding {
     ) throws -> T.Wrapped?
         where Strategy: ValueCodableStrategy,
         Strategy.Value == T.Wrapped,
-        T: Decodable,
         T: OptionalProtocol
     {
         if container.contains(key) {
@@ -782,8 +780,7 @@ public extension CustomCodingDecoding {
         where Strategy: ValueCodableStrategy,
         Strategy.Value == T,
         Provider: DefaultValueProvider,
-        Provider.DefaultValue == T,
-        T: Decodable
+        Provider.DefaultValue == T
     {
         do {
             return try decode(type, forKey: key, container: container, strategy: strategy)
@@ -805,7 +802,6 @@ public extension CustomCodingDecoding {
         Strategy.Value == T.Wrapped,
         Provider: DefaultValueProvider,
         Provider.DefaultValue == T.Wrapped,
-        T: Decodable,
         T: OptionalProtocol
     {
         try decode(T.Wrapped.self, forKey: key, container: container, strategy: strategy, provider: provider)

--- a/Sources/MacroCodableKit/Misc/CustomCoding/Types/CustomCodingEncoding+Types.swift
+++ b/Sources/MacroCodableKit/Misc/CustomCoding/Types/CustomCodingEncoding+Types.swift
@@ -225,8 +225,7 @@ public extension CustomCodingEncoding {
         strategy: Strategy.Type
     ) throws
         where Strategy: ValueCodableStrategy,
-        Strategy.Value == T,
-        T: Encodable
+        Strategy.Value == T
     {
         let encoder = container.superEncoder(forKey: key)
         try strategy.encode(value: value, to: encoder)
@@ -240,7 +239,6 @@ public extension CustomCodingEncoding {
     ) throws
         where Strategy: ValueCodableStrategy,
         Strategy.Value == T.Wrapped,
-        T: Encodable,
         T: OptionalProtocol
     {
         guard let unwrappedValue = value.asOptional() else { return }

--- a/Sources/MacroCodableKit/Misc/ValueCodableStrategy.swift
+++ b/Sources/MacroCodableKit/Misc/ValueCodableStrategy.swift
@@ -5,16 +5,12 @@
 //  Created by Mikhail Maslo on 30.09.23.
 //
 
-/**
- A strategy for encoding and decoding a specific value type.
-
- - Note: The value type must conform to `Codable`.
-
- - SeeAlso: `ValueStrategy`
- */
-public protocol ValueCodableStrategy {
+/// A strategy for encoding and decoding a specific value type.
+///
+/// The value type must conform to `Codable`.
+public protocol ValueCodableStrategy<Value> {
     /// The type of value that this strategy encodes and decodes.
-    associatedtype Value: Codable
+    associatedtype Value
 
     /**
      Decodes a value of the associated type from the given decoder.


### PR DESCRIPTION
It’s not required for Value since in `ValueCodableStrategy` it’s possible to rule out concrete types to decode & encode which will confirm to decodable & decodable

For example, Strategy can decode & encode string while transforming value to, for example, a custom type which doesn’t necessarelly confirms to Codable